### PR TITLE
add employmentTypes and jobLocations methods

### DIFF
--- a/src/JobPosting.php
+++ b/src/JobPosting.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\SchemaOrg;
 
+use Spatie\SchemaOrg\Exceptions\InvalidProperty;
+
 /**
  * A listing that describes a job opening in a certain organization.
  *
@@ -95,6 +97,23 @@ class JobPosting extends Intangible
     }
 
     /**
+     * Types of employment
+     *
+     * Allowed Values: FULL_TIME, PART_TIME, CONTRACTOR, TEMPORARY,
+     * INTERN, VOLUNTEER, PER_DIEM, OTHER
+     *
+     * @param array ...$employmentTypes
+     *
+     * @return static
+     *
+     * @see https://developers.google.com/search/docs/data-types/job-postings
+     */
+    public function employmentTypes(... $employmentTypes)
+    {
+        return $this->setProperty('employmentType', $employmentTypes);
+    }
+
+    /**
      * Description of skills and experience needed for the position.
      *
      * @param string $experienceRequirements
@@ -177,6 +196,17 @@ class JobPosting extends Intangible
     public function jobLocation($jobLocation)
     {
         return $this->setProperty('jobLocation', $jobLocation);
+    }
+
+    public function jobLocations(... $jobLocations)
+    {
+        foreach ($jobLocations as $jobLocation) {
+            if (!$jobLocation instanceof Place) {
+                throw new InvalidProperty("A Job Location must be of type Place");
+            }
+        }
+
+        return $this->setProperty('jobLocation', $jobLocations);
     }
 
     /**

--- a/src/JobPosting.php
+++ b/src/JobPosting.php
@@ -198,6 +198,15 @@ class JobPosting extends Intangible
         return $this->setProperty('jobLocation', $jobLocation);
     }
 
+    /**
+     * An array of geographic locations associated with the job position
+     *
+     * @param array ...$jobLocations an array of Place objects
+     *
+     * @return static
+     *
+     * @throws InvalidProperty when other object types are passed in
+     */
     public function jobLocations(... $jobLocations)
     {
         foreach ($jobLocations as $jobLocation) {

--- a/tests/JobPostingTest.php
+++ b/tests/JobPostingTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Skeleton\Test;
 
-use PHPUnit\Framework\TestCase;
-use Spatie\SchemaOrg\Exceptions\InvalidProperty;
-use Spatie\SchemaOrg\JobPosting;
 use Spatie\SchemaOrg\Schema;
+use PHPUnit\Framework\TestCase;
+use Spatie\SchemaOrg\JobPosting;
+use Spatie\SchemaOrg\Exceptions\InvalidProperty;
 
 class JobPostingTest extends TestCase
 {

--- a/tests/JobPostingTest.php
+++ b/tests/JobPostingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\Skeleton\Test;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\SchemaOrg\Exceptions\InvalidProperty;
+use Spatie\SchemaOrg\JobPosting;
+use Spatie\SchemaOrg\Schema;
+
+class JobPostingTest extends TestCase
+{
+    /** @test */
+    public function it_can_add_multiple_employment_types()
+    {
+        $jobPosting = new JobPosting();
+
+        $jobPosting->employmentTypes('FULL_TIME', 'PART_TIME');
+
+        $this->assertEquals(['FULL_TIME', 'PART_TIME'], $jobPosting->getProperty('employmentType'));
+    }
+
+    /** @test */
+    public function it_can_add_multiple_job_locations()
+    {
+        $jobPosting = new JobPosting();
+
+        $firstLocation = Schema::place()->name('First Location');
+        $secondLocation = Schema::place()->name('Second Location');
+
+        $jobPosting->jobLocations($firstLocation, $secondLocation);
+
+        $this->assertEquals([$firstLocation, $secondLocation], $jobPosting->getProperty('jobLocation'));
+    }
+
+    /** @test */
+    public function it_should_only_accept_job_locations_of_type_place()
+    {
+        $this->expectException(InvalidProperty::class);
+
+        $jobPosting = new JobPosting();
+
+        $jobPosting->jobLocations('a string');
+    }
+}


### PR DESCRIPTION
As defined in the [Google Search Job Postings](https://developers.google.com/search/docs/data-types/job-postings) specification, a JobPosting should be able to support multiple employmentTypes and jobLocations.