### PR TITLE
add ability to add multiple properties at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ All properties can be retrieved as an array with the `getProperties` method.
 $localBusiness->getProperties(); // ['name' => 'Spatie', ...]
 ```
 
+Multiple properties can be set at once using the `addProperties` method.
+
+```php
+$localBusiness->addProperties(['name' => 'value', 'foo' => 'bar']);
+```
+
 Context and type can be retrieved with the `getContext` and `getType` methods.
 
 ```php
@@ -170,6 +176,7 @@ If you discover any security related issues, please email freek@spatie.be instea
 - [All Contributors](../../contributors)
 
 ## About Spatie
+
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
 ## License

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -29,6 +29,15 @@ abstract class BaseType implements Type
         return $this;
     }
 
+    public function addProperties(array $properties)
+    {
+        foreach ($properties as $property => $value) {
+            $this->properties[$property] = $value;
+        }
+
+        return $this;
+    }
+
     public function if($condition, $callback)
     {
         if ($condition) {

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -61,13 +61,13 @@ class BaseTypeTest extends TestCase
 
         $type->addProperties([
             'foo' => 'bar',
-            'baz' => 'qux'
+            'baz' => 'qux',
         ]);
 
         $this->assertEquals(
             [
                 'foo' => 'bar',
-                'baz' => 'qux'
+                'baz' => 'qux',
             ],
             $type->getProperties()
         );

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -55,6 +55,25 @@ class BaseTypeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_add_multiple_properties_at_once()
+    {
+        $type = new DummyType();
+
+        $type->addProperties([
+            'foo' => 'bar',
+            'baz' => 'qux'
+        ]);
+
+        $this->assertEquals(
+            [
+                'foo' => 'bar',
+                'baz' => 'qux'
+            ],
+            $type->getProperties()
+        );
+    }
+
+    /** @test */
     public function it_can_create_an_array_that_conforms_to_the_ld_json_spec_with_primitive_properties()
     {
         $type = new DummyType();


### PR DESCRIPTION
via the `addProperties()` method on the `BaseType`. Example:

```php
Schema::thing()->addProperties($array);
```

I didn't change the CHANGELOG as I don't know whether that should be part of the pull request. I would appreciate a release tag in case this pull requests is accepted.

Thanks for the lib. :-)