### PR TITLE
Add Physician to MedicalOrganization

### DIFF
--- a/src/Physician.php
+++ b/src/Physician.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A physician.
+ *
+ * @see http://schema.org/Physician
+ */
+class Physician extends MedicalOrganization
+{
+}

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1967,6 +1967,11 @@ class Schema
         return new PhotographAction();
     }
 
+    public static function physician(): Physician
+    {
+        return new Physician();
+    }
+
     public static function place(): Place
     {
         return new Place();


### PR DESCRIPTION
For some reason *Physician* (http://schema.org/Physician) is missing from MedicalOrganization. *Dentist* and *Pharmacy* are in there though.

This adds *physician* to MedicalOrganization