### PR TITLE
remove deprecated styleci linting

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,5 @@
 preset: laravel
 
-linting: true
-
 disabled:
   - single_class_element_per_statement
 


### PR DESCRIPTION
https://styleci.readme.io/docs/change-log#section-14042018-april-fixer-updates
> Finally, the long deprecated "linting" config option has now been removed.