### PR TITLE
[fix] Generator does not use latest RDFA file

### DIFF
--- a/generator/Console/GenerateCommand.php
+++ b/generator/Console/GenerateCommand.php
@@ -32,7 +32,7 @@ class GenerateCommand extends Command
         $generator = new PackageGenerator();
 
         $definitions = new Definitions([
-            'core' => 'https://raw.githubusercontent.com/schemaorg/schemaorg/sdo-callisto/data/schema.rdfa',
+            'core' => 'https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/schema.rdfa',
         ]);
 
         if (! $input->getOption('local')) {

--- a/src/Accommodation.php
+++ b/src/Accommodation.php
@@ -51,7 +51,7 @@ class Accommodation extends Place
 
     /**
      * The number of rooms (excluding bathrooms and closets) of the
-     * acccommodation or lodging business.
+     * accommodation or lodging business.
      * Typical unit code(s): ROM for room or C62 for no unit. The type of room
      * can be put in the unitText property of the QuantitativeValue.
      *

--- a/src/Apartment.php
+++ b/src/Apartment.php
@@ -14,7 +14,7 @@ class Apartment extends Accommodation
 {
     /**
      * The number of rooms (excluding bathrooms and closets) of the
-     * acccommodation or lodging business.
+     * accommodation or lodging business.
      * Typical unit code(s): ROM for room or C62 for no unit. The type of room
      * can be put in the unitText property of the QuantitativeValue.
      *

--- a/src/AuthorizeAction.php
+++ b/src/AuthorizeAction.php
@@ -13,7 +13,7 @@ class AuthorizeAction extends AllocateAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/Blog.php
+++ b/src/Blog.php
@@ -37,4 +37,20 @@ class Blog extends CreativeWork
         return $this->setProperty('blogPosts', $blogPosts);
     }
 
+    /**
+     * The International Standard Serial Number (ISSN) that identifies this
+     * serial publication. You can repeat this property to identify different
+     * formats of, or the linking ISSN (ISSN-L) for, this serial publication.
+     *
+     * @param string|string[] $issn
+     *
+     * @return static
+     *
+     * @see http://schema.org/issn
+     */
+    public function issn($issn)
+    {
+        return $this->setProperty('issn', $issn);
+    }
+
 }

--- a/src/BusTrip.php
+++ b/src/BusTrip.php
@@ -7,7 +7,7 @@ namespace Spatie\SchemaOrg;
  *
  * @see http://schema.org/BusTrip
  */
-class BusTrip extends Intangible
+class BusTrip extends Trip
 {
     /**
      * The stop or station from which the bus arrives.
@@ -21,20 +21,6 @@ class BusTrip extends Intangible
     public function arrivalBusStop($arrivalBusStop)
     {
         return $this->setProperty('arrivalBusStop', $arrivalBusStop);
-    }
-
-    /**
-     * The expected arrival time.
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $arrivalTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/arrivalTime
-     */
-    public function arrivalTime($arrivalTime)
-    {
-        return $this->setProperty('arrivalTime', $arrivalTime);
     }
 
     /**
@@ -77,36 +63,6 @@ class BusTrip extends Intangible
     public function departureBusStop($departureBusStop)
     {
         return $this->setProperty('departureBusStop', $departureBusStop);
-    }
-
-    /**
-     * The expected departure time.
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $departureTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/departureTime
-     */
-    public function departureTime($departureTime)
-    {
-        return $this->setProperty('departureTime', $departureTime);
-    }
-
-    /**
-     * The service provider, service operator, or service performer; the goods
-     * producer. Another party (a seller) may offer those services or goods on
-     * behalf of the provider. A provider may also serve as the seller.
-     *
-     * @param Organization|Organization[]|Person|Person[] $provider
-     *
-     * @return static
-     *
-     * @see http://schema.org/provider
-     */
-    public function provider($provider)
-    {
-        return $this->setProperty('provider', $provider);
     }
 
 }

--- a/src/CommunicateAction.php
+++ b/src/CommunicateAction.php
@@ -59,7 +59,7 @@ class CommunicateAction extends InteractAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/ContactPoint.php
+++ b/src/ContactPoint.php
@@ -24,9 +24,9 @@ class ContactPoint extends StructuredValue
     }
 
     /**
-     * A language someone may use with the item. Please use one of the language
-     * codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47).
-     * See also [[inLanguage]]
+     * A language someone may use with or at the item, service or place. Please
+     * use one of the language codes from the [IETF BCP 47
+     * standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]
      *
      * @param Language|Language[]|string|string[] $availableLanguage
      *

--- a/src/Corporation.php
+++ b/src/Corporation.php
@@ -13,7 +13,7 @@ class Corporation extends Organization
      * The exchange traded instrument associated with a Corporation object. The
      * tickerSymbol is expressed as an exchange and an instrument name separated
      * by a space character. For the exchange component of the tickerSymbol
-     * attribute, we reccommend using the controlled vocaulary of Market
+     * attribute, we recommend using the controlled vocabulary of Market
      * Identifier Codes (MIC) specified in ISO15022.
      *
      * @param string|string[] $tickerSymbol

--- a/src/CreativeWork.php
+++ b/src/CreativeWork.php
@@ -347,7 +347,7 @@ class CreativeWork extends Thing
     /**
      * Official rating of a piece of content&#x2014;for example,'MPAA PG-13'.
      *
-     * @param string|string[] $contentRating
+     * @param Rating|Rating[]|string|string[] $contentRating
      *
      * @return static
      *
@@ -533,6 +533,33 @@ class CreativeWork extends Thing
     }
 
     /**
+     * Media type typically expressed using a MIME format (see [IANA
+     * site](http://www.iana.org/assignments/media-types/media-types.xhtml) and
+     * [MDN
+     * reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types))
+     * e.g. application/zip for a SoftwareApplication binary, audio/mpeg for
+     * .mp3 etc.).
+     * 
+     * In cases where a [[CreativeWork]] has several media type representations,
+     * [[encoding]] can be used to indicate each [[MediaObject]] alongside
+     * particular [[encodingFormat]] information.
+     * 
+     * Unregistered or niche encoding and file formats can be indicated instead
+     * via the most appropriate URL, e.g. defining Web page or a
+     * Wikipedia/Wikidata entry.
+     *
+     * @param string|string[] $encodingFormat
+     *
+     * @return static
+     *
+     * @see http://schema.org/encodingFormat
+     */
+    public function encodingFormat($encodingFormat)
+    {
+        return $this->setProperty('encodingFormat', $encodingFormat);
+    }
+
+    /**
      * A media object that encodes this CreativeWork.
      *
      * @param MediaObject|MediaObject[] $encodings
@@ -559,6 +586,24 @@ class CreativeWork extends Thing
     public function exampleOfWork($exampleOfWork)
     {
         return $this->setProperty('exampleOfWork', $exampleOfWork);
+    }
+
+    /**
+     * Date the content expires and is no longer useful or available. For
+     * example a [[VideoObject]] or [[NewsArticle]] whose availability or
+     * relevance is time-limited, or a [[ClaimReview]] fact check whose
+     * publisher wants to indicate that it may no longer be relevant (or helpful
+     * to highlight) after some date.
+     *
+     * @param \DateTimeInterface|\DateTimeInterface[] $expires
+     *
+     * @return static
+     *
+     * @see http://schema.org/expires
+     */
+    public function expires($expires)
+    {
+        return $this->setProperty('expires', $expires);
     }
 
     /**
@@ -612,8 +657,8 @@ class CreativeWork extends Thing
     }
 
     /**
-     * Indicates a CreativeWork that is (in some sense) a part of this
-     * CreativeWork.
+     * Indicates an item or CreativeWork that is part of this item, or
+     * CreativeWork (in some sense).
      *
      * @param CreativeWork|CreativeWork[] $hasPart
      *
@@ -689,7 +734,7 @@ class CreativeWork extends Thing
     }
 
     /**
-     * A flag to signal that the publication is accessible for free.
+     * A flag to signal that the item, event, or place is accessible for free.
      *
      * @param bool|bool[] $isAccessibleForFree
      *
@@ -749,8 +794,8 @@ class CreativeWork extends Thing
     }
 
     /**
-     * Indicates a CreativeWork that this CreativeWork is (in some sense) part
-     * of.
+     * Indicates an item or CreativeWork that this item, or CreativeWork (in
+     * some sense), is part of.
      *
      * @param CreativeWork|CreativeWork[] $isPartOf
      *
@@ -958,10 +1003,19 @@ class CreativeWork extends Thing
     }
 
     /**
-     * Link to page describing the editorial principles of the organization
-     * primarily responsible for the creation of the CreativeWork.
+     * The publishingPrinciples property indicates (typically via [[URL]]) a
+     * document describing the editorial principles of an [[Organization]] (or
+     * individual e.g. a [[Person]] writing a blog) that relate to their
+     * activities as a publisher, e.g. ethics or diversity policies. When
+     * applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are
+     * those of the party primarily responsible for the creation of the
+     * [[CreativeWork]].
+     * 
+     * While such policies are most typically expressed in natural language,
+     * sometimes related information (e.g. indicating a [[funder]]) can be
+     * expressed using schema.org terminology.
      *
-     * @param string|string[] $publishingPrinciples
+     * @param CreativeWork|CreativeWork[]|string|string[] $publishingPrinciples
      *
      * @return static
      *

--- a/src/CreativeWorkSeries.php
+++ b/src/CreativeWorkSeries.php
@@ -41,6 +41,22 @@ class CreativeWorkSeries extends CreativeWork
     }
 
     /**
+     * The International Standard Serial Number (ISSN) that identifies this
+     * serial publication. You can repeat this property to identify different
+     * formats of, or the linking ISSN (ISSN-L) for, this serial publication.
+     *
+     * @param string|string[] $issn
+     *
+     * @return static
+     *
+     * @see http://schema.org/issn
+     */
+    public function issn($issn)
+    {
+        return $this->setProperty('issn', $issn);
+    }
+
+    /**
      * The start date and time of the item (in [ISO 8601 date
      * format](http://en.wikipedia.org/wiki/ISO_8601)).
      *

--- a/src/Dataset.php
+++ b/src/Dataset.php
@@ -83,6 +83,22 @@ class Dataset extends CreativeWork
     }
 
     /**
+     * The International Standard Serial Number (ISSN) that identifies this
+     * serial publication. You can repeat this property to identify different
+     * formats of, or the linking ISSN (ISSN-L) for, this serial publication.
+     *
+     * @param string|string[] $issn
+     *
+     * @return static
+     *
+     * @see http://schema.org/issn
+     */
+    public function issn($issn)
+    {
+        return $this->setProperty('issn', $issn);
+    }
+
+    /**
      * The range of spatial applicability of a dataset, e.g. for a dataset of
      * New York weather, the state of New York.
      *

--- a/src/DatedMoneySpecification.php
+++ b/src/DatedMoneySpecification.php
@@ -27,8 +27,15 @@ class DatedMoneySpecification extends StructuredValue
     }
 
     /**
-     * The currency in which the monetary amount is expressed (in 3-letter [ISO
-     * 4217](http://en.wikipedia.org/wiki/ISO_4217) format).
+     * The currency in which the monetary amount is expressed.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $currency
      *

--- a/src/Demand.php
+++ b/src/Demand.php
@@ -240,11 +240,11 @@ class Demand extends Intangible
     }
 
     /**
-     * The [GTIN-12](http://apps.gs1.org/GDD/glossary/Pages/GTIN-12.aspx) code
-     * of the product, or the product to which the offer refers. The GTIN-12 is
-     * the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix,
-     * Item Reference, and Check Digit used to identify trade items. See [GS1
-     * GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
+     * The GTIN-12 code of the product, or the product to which the offer
+     * refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a
+     * U.P.C. Company Prefix, Item Reference, and Check Digit used to identify
+     * trade items. See [GS1 GTIN
+     * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *
      * @param string|string[] $gtin12
@@ -259,11 +259,10 @@ class Demand extends Intangible
     }
 
     /**
-     * The [GTIN-13](http://apps.gs1.org/GDD/glossary/Pages/GTIN-13.aspx) code
-     * of the product, or the product to which the offer refers. This is
-     * equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC
-     * codes can be converted into a GTIN-13 code by simply adding a preceeding
-     * zero. See [GS1 GTIN
+     * The GTIN-13 code of the product, or the product to which the offer
+     * refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former
+     * 12-digit UPC codes can be converted into a GTIN-13 code by simply adding
+     * a preceeding zero. See [GS1 GTIN
      * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *
@@ -279,8 +278,8 @@ class Demand extends Intangible
     }
 
     /**
-     * The [GTIN-14](http://apps.gs1.org/GDD/glossary/Pages/GTIN-14.aspx) code
-     * of the product, or the product to which the offer refers. See [GS1 GTIN
+     * The GTIN-14 code of the product, or the product to which the offer
+     * refers. See [GS1 GTIN
      * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *

--- a/src/DonateAction.php
+++ b/src/DonateAction.php
@@ -14,7 +14,7 @@ class DonateAction extends TradeAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/Event.php
+++ b/src/Event.php
@@ -235,7 +235,7 @@ class Event extends Thing
     }
 
     /**
-     * A flag to signal that the publication is accessible for free.
+     * A flag to signal that the item, event, or place is accessible for free.
      *
      * @param bool|bool[] $isAccessibleForFree
      *

--- a/src/Flight.php
+++ b/src/Flight.php
@@ -7,7 +7,7 @@ namespace Spatie\SchemaOrg;
  *
  * @see http://schema.org/Flight
  */
-class Flight extends Intangible
+class Flight extends Trip
 {
     /**
      * The kind of aircraft (e.g., "Boeing 747").
@@ -63,20 +63,6 @@ class Flight extends Intangible
     public function arrivalTerminal($arrivalTerminal)
     {
         return $this->setProperty('arrivalTerminal', $arrivalTerminal);
-    }
-
-    /**
-     * The expected arrival time.
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $arrivalTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/arrivalTime
-     */
-    public function arrivalTime($arrivalTime)
-    {
-        return $this->setProperty('arrivalTime', $arrivalTime);
     }
 
     /**
@@ -152,20 +138,6 @@ class Flight extends Intangible
     }
 
     /**
-     * The expected departure time.
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $departureTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/departureTime
-     */
-    public function departureTime($departureTime)
-    {
-        return $this->setProperty('departureTime', $departureTime);
-    }
-
-    /**
      * The estimated time the flight will take.
      *
      * @param Duration|Duration[]|string|string[] $estimatedFlightDuration
@@ -221,22 +193,6 @@ class Flight extends Intangible
     public function mealService($mealService)
     {
         return $this->setProperty('mealService', $mealService);
-    }
-
-    /**
-     * The service provider, service operator, or service performer; the goods
-     * producer. Another party (a seller) may offer those services or goods on
-     * behalf of the provider. A provider may also serve as the seller.
-     *
-     * @param Organization|Organization[]|Person|Person[] $provider
-     *
-     * @return static
-     *
-     * @see http://schema.org/provider
-     */
-    public function provider($provider)
-    {
-        return $this->setProperty('provider', $provider);
     }
 
     /**

--- a/src/FoodEstablishmentReservation.php
+++ b/src/FoodEstablishmentReservation.php
@@ -3,9 +3,11 @@
 namespace Spatie\SchemaOrg;
 
 /**
- * A reservation to dine at a food-related business.Note: This type is for
- * information about actual reservations, e.g. in confirmation emails or HTML
- * pages with individual confirmations of reservations.
+ * A reservation to dine at a food-related business.
+ * 
+ * Note: This type is for information about actual reservations, e.g. in
+ * confirmation emails or HTML pages with individual confirmations of
+ * reservations.
  *
  * @see http://schema.org/FoodEstablishmentReservation
  */

--- a/src/GiveAction.php
+++ b/src/GiveAction.php
@@ -21,7 +21,7 @@ class GiveAction extends TransferAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/House.php
+++ b/src/House.php
@@ -14,7 +14,7 @@ class House extends Accommodation
 {
     /**
      * The number of rooms (excluding bathrooms and closets) of the
-     * acccommodation or lodging business.
+     * accommodation or lodging business.
      * Typical unit code(s): ROM for room or C62 for no unit. The type of room
      * can be put in the unitText property of the QuantitativeValue.
      *

--- a/src/HowTo.php
+++ b/src/HowTo.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * Instructions that explain how to achieve a result by performing a sequence of
+ * steps.
+ *
+ * @see http://schema.org/HowTo
+ */
+class HowTo extends CreativeWork
+{
+    /**
+     * The estimated cost of the supply or supplies consumed when performing
+     * instructions.
+     *
+     * @param MonetaryAmount|MonetaryAmount[]|string|string[] $estimatedCost
+     *
+     * @return static
+     *
+     * @see http://schema.org/estimatedCost
+     */
+    public function estimatedCost($estimatedCost)
+    {
+        return $this->setProperty('estimatedCost', $estimatedCost);
+    }
+
+    /**
+     * The length of time it takes to perform instructions or a direction (not
+     * including time to prepare the supplies), in [ISO 8601 duration
+     * format](http://en.wikipedia.org/wiki/ISO_8601).
+     *
+     * @param Duration|Duration[] $performTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/performTime
+     */
+    public function performTime($performTime)
+    {
+        return $this->setProperty('performTime', $performTime);
+    }
+
+    /**
+     * The length of time it takes to prepare the items to be used in
+     * instructions or a direction, in [ISO 8601 duration
+     * format](http://en.wikipedia.org/wiki/ISO_8601).
+     *
+     * @param Duration|Duration[] $prepTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/prepTime
+     */
+    public function prepTime($prepTime)
+    {
+        return $this->setProperty('prepTime', $prepTime);
+    }
+
+    /**
+     * A single step item (as HowToStep, text, document, video, etc.) or a
+     * HowToSection.
+     *
+     * @param CreativeWork|CreativeWork[]|HowToSection|HowToSection[]|HowToStep|HowToStep[]|string|string[] $step
+     *
+     * @return static
+     *
+     * @see http://schema.org/step
+     */
+    public function step($step)
+    {
+        return $this->setProperty('step', $step);
+    }
+
+    /**
+     * A single step item (as HowToStep, text, document, video, etc.) or a
+     * HowToSection (originally misnamed 'steps'; 'step' is preferred).
+     *
+     * @param CreativeWork|CreativeWork[]|ItemList|ItemList[]|string|string[] $steps
+     *
+     * @return static
+     *
+     * @see http://schema.org/steps
+     */
+    public function steps($steps)
+    {
+        return $this->setProperty('steps', $steps);
+    }
+
+    /**
+     * A sub-property of instrument. A supply consumed when performing
+     * instructions or a direction.
+     *
+     * @param HowToSupply|HowToSupply[]|string|string[] $supply
+     *
+     * @return static
+     *
+     * @see http://schema.org/supply
+     */
+    public function supply($supply)
+    {
+        return $this->setProperty('supply', $supply);
+    }
+
+    /**
+     * A sub property of instrument. An object used (but not consumed) when
+     * performing instructions or a direction.
+     *
+     * @param HowToTool|HowToTool[]|string|string[] $tool
+     *
+     * @return static
+     *
+     * @see http://schema.org/tool
+     */
+    public function tool($tool)
+    {
+        return $this->setProperty('tool', $tool);
+    }
+
+    /**
+     * The total time required to perform instructions or a direction (including
+     * time to prepare the supplies), in [ISO 8601 duration
+     * format](http://en.wikipedia.org/wiki/ISO_8601).
+     *
+     * @param Duration|Duration[] $totalTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/totalTime
+     */
+    public function totalTime($totalTime)
+    {
+        return $this->setProperty('totalTime', $totalTime);
+    }
+
+    /**
+     * The quantity that results by performing instructions. For example, a
+     * paper airplane, 10 personalized candles.
+     *
+     * @param QuantitativeValue|QuantitativeValue[]|string|string[] $yield
+     *
+     * @return static
+     *
+     * @see http://schema.org/yield
+     */
+    public function yield($yield)
+    {
+        return $this->setProperty('yield', $yield);
+    }
+
+}

--- a/src/HowToDirection.php
+++ b/src/HowToDirection.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A direction indicating a single action to do in the instructions for how to
+ * achieve a result.
+ *
+ * @see http://schema.org/HowToDirection
+ */
+class HowToDirection extends ListItem
+{
+    /**
+     * A media object representing the circumstances after performing this
+     * direction.
+     *
+     * @param MediaObject|MediaObject[]|string|string[] $afterMedia
+     *
+     * @return static
+     *
+     * @see http://schema.org/afterMedia
+     */
+    public function afterMedia($afterMedia)
+    {
+        return $this->setProperty('afterMedia', $afterMedia);
+    }
+
+    /**
+     * A media object representing the circumstances before performing this
+     * direction.
+     *
+     * @param MediaObject|MediaObject[]|string|string[] $beforeMedia
+     *
+     * @return static
+     *
+     * @see http://schema.org/beforeMedia
+     */
+    public function beforeMedia($beforeMedia)
+    {
+        return $this->setProperty('beforeMedia', $beforeMedia);
+    }
+
+    /**
+     * A media object representing the circumstances while performing this
+     * direction.
+     *
+     * @param MediaObject|MediaObject[]|string|string[] $duringMedia
+     *
+     * @return static
+     *
+     * @see http://schema.org/duringMedia
+     */
+    public function duringMedia($duringMedia)
+    {
+        return $this->setProperty('duringMedia', $duringMedia);
+    }
+
+    /**
+     * The length of time it takes to perform instructions or a direction (not
+     * including time to prepare the supplies), in [ISO 8601 duration
+     * format](http://en.wikipedia.org/wiki/ISO_8601).
+     *
+     * @param Duration|Duration[] $performTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/performTime
+     */
+    public function performTime($performTime)
+    {
+        return $this->setProperty('performTime', $performTime);
+    }
+
+    /**
+     * The length of time it takes to prepare the items to be used in
+     * instructions or a direction, in [ISO 8601 duration
+     * format](http://en.wikipedia.org/wiki/ISO_8601).
+     *
+     * @param Duration|Duration[] $prepTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/prepTime
+     */
+    public function prepTime($prepTime)
+    {
+        return $this->setProperty('prepTime', $prepTime);
+    }
+
+    /**
+     * A sub-property of instrument. A supply consumed when performing
+     * instructions or a direction.
+     *
+     * @param HowToSupply|HowToSupply[]|string|string[] $supply
+     *
+     * @return static
+     *
+     * @see http://schema.org/supply
+     */
+    public function supply($supply)
+    {
+        return $this->setProperty('supply', $supply);
+    }
+
+    /**
+     * A sub property of instrument. An object used (but not consumed) when
+     * performing instructions or a direction.
+     *
+     * @param HowToTool|HowToTool[]|string|string[] $tool
+     *
+     * @return static
+     *
+     * @see http://schema.org/tool
+     */
+    public function tool($tool)
+    {
+        return $this->setProperty('tool', $tool);
+    }
+
+    /**
+     * The total time required to perform instructions or a direction (including
+     * time to prepare the supplies), in [ISO 8601 duration
+     * format](http://en.wikipedia.org/wiki/ISO_8601).
+     *
+     * @param Duration|Duration[] $totalTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/totalTime
+     */
+    public function totalTime($totalTime)
+    {
+        return $this->setProperty('totalTime', $totalTime);
+    }
+
+}

--- a/src/HowToItem.php
+++ b/src/HowToItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * An item used as either a tool or supply when performing the instructions for
+ * how to to achieve a result.
+ *
+ * @see http://schema.org/HowToItem
+ */
+class HowToItem extends ListItem
+{
+    /**
+     * The required quantity of the item(s).
+     *
+     * @param QuantitativeValue|QuantitativeValue[]|float|float[]|int|int[]|string|string[] $requiredQuantity
+     *
+     * @return static
+     *
+     * @see http://schema.org/requiredQuantity
+     */
+    public function requiredQuantity($requiredQuantity)
+    {
+        return $this->setProperty('requiredQuantity', $requiredQuantity);
+    }
+
+}

--- a/src/HowToSection.php
+++ b/src/HowToSection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A sub-grouping of steps in the instructions for how to achieve a result (e.g.
+ * steps for making a pie crust within a pie recipe).
+ *
+ * @see http://schema.org/HowToSection
+ */
+class HowToSection extends ItemList
+{
+    /**
+     * A single step item (as HowToStep, text, document, video, etc.) or a
+     * HowToSection (originally misnamed 'steps'; 'step' is preferred).
+     *
+     * @param CreativeWork|CreativeWork[]|ItemList|ItemList[]|string|string[] $steps
+     *
+     * @return static
+     *
+     * @see http://schema.org/steps
+     */
+    public function steps($steps)
+    {
+        return $this->setProperty('steps', $steps);
+    }
+
+}

--- a/src/HowToStep.php
+++ b/src/HowToStep.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A step in the instructions for how to achieve a result. It is an ordered list
+ * with HowToDirection and/or HowToTip items.
+ *
+ * @see http://schema.org/HowToStep
+ */
+class HowToStep extends ListItem
+{
+}

--- a/src/HowToSupply.php
+++ b/src/HowToSupply.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A supply consumed when performing the instructions for how to achieve a
+ * result.
+ *
+ * @see http://schema.org/HowToSupply
+ */
+class HowToSupply extends HowToItem
+{
+    /**
+     * The estimated cost of the supply or supplies consumed when performing
+     * instructions.
+     *
+     * @param MonetaryAmount|MonetaryAmount[]|string|string[] $estimatedCost
+     *
+     * @return static
+     *
+     * @see http://schema.org/estimatedCost
+     */
+    public function estimatedCost($estimatedCost)
+    {
+        return $this->setProperty('estimatedCost', $estimatedCost);
+    }
+
+}

--- a/src/HowToTip.php
+++ b/src/HowToTip.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * An explanation in the instructions for how to achieve a result. It provides
+ * supplementary information about a technique, supply, author's preference,
+ * etc. It can explain what could be done, or what should not be done, but
+ * doesn't specify what should be done (see HowToDirection).
+ *
+ * @see http://schema.org/HowToTip
+ */
+class HowToTip extends ListItem
+{
+}

--- a/src/HowToTool.php
+++ b/src/HowToTool.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A tool used (but not consumed) when performing instructions for how to
+ * achieve a result.
+ *
+ * @see http://schema.org/HowToTool
+ */
+class HowToTool extends HowToItem
+{
+}

--- a/src/LocalBusiness.php
+++ b/src/LocalBusiness.php
@@ -27,8 +27,15 @@ class LocalBusiness extends Organization
     }
 
     /**
-     * The currency accepted (in [ISO 4217 currency
-     * format](http://en.wikipedia.org/wiki/ISO_4217)).
+     * The currency accepted.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $currenciesAccepted
      *
@@ -71,7 +78,7 @@ class LocalBusiness extends Organization
     }
 
     /**
-     * Cash, credit card, etc.
+     * Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc.
      *
      * @param string|string[] $paymentAccepted
      *

--- a/src/LodgingBusiness.php
+++ b/src/LodgingBusiness.php
@@ -41,9 +41,9 @@ class LodgingBusiness extends LocalBusiness
     }
 
     /**
-     * A language someone may use with the item. Please use one of the language
-     * codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47).
-     * See also [[inLanguage]]
+     * A language someone may use with or at the item, service or place. Please
+     * use one of the language codes from the [IETF BCP 47
+     * standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]
      *
      * @param Language|Language[]|string|string[] $availableLanguage
      *

--- a/src/MediaObject.php
+++ b/src/MediaObject.php
@@ -116,7 +116,20 @@ class MediaObject extends CreativeWork
     }
 
     /**
-     * mp3, mpeg4, etc.
+     * Media type typically expressed using a MIME format (see [IANA
+     * site](http://www.iana.org/assignments/media-types/media-types.xhtml) and
+     * [MDN
+     * reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types))
+     * e.g. application/zip for a SoftwareApplication binary, audio/mpeg for
+     * .mp3 etc.).
+     * 
+     * In cases where a [[CreativeWork]] has several media type representations,
+     * [[encoding]] can be used to indicate each [[MediaObject]] alongside
+     * particular [[encodingFormat]] information.
+     * 
+     * Unregistered or niche encoding and file formats can be indicated instead
+     * via the most appropriate URL, e.g. defining Web page or a
+     * Wikipedia/Wikidata entry.
      *
      * @param string|string[] $encodingFormat
      *
@@ -127,21 +140,6 @@ class MediaObject extends CreativeWork
     public function encodingFormat($encodingFormat)
     {
         return $this->setProperty('encodingFormat', $encodingFormat);
-    }
-
-    /**
-     * Date the content expires and is no longer useful or available. Useful for
-     * videos.
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $expires
-     *
-     * @return static
-     *
-     * @see http://schema.org/expires
-     */
-    public function expires($expires)
-    {
-        return $this->setProperty('expires', $expires);
     }
 
     /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,6 +10,34 @@ namespace Spatie\SchemaOrg;
 class Message extends CreativeWork
 {
     /**
+     * A sub property of recipient. The recipient blind copied on a message.
+     *
+     * @param ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $bccRecipient
+     *
+     * @return static
+     *
+     * @see http://schema.org/bccRecipient
+     */
+    public function bccRecipient($bccRecipient)
+    {
+        return $this->setProperty('bccRecipient', $bccRecipient);
+    }
+
+    /**
+     * A sub property of recipient. The recipient copied on a message.
+     *
+     * @param ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $ccRecipient
+     *
+     * @return static
+     *
+     * @see http://schema.org/ccRecipient
+     */
+    public function ccRecipient($ccRecipient)
+    {
+        return $this->setProperty('ccRecipient', $ccRecipient);
+    }
+
+    /**
      * The date/time at which the message has been read by the recipient if a
      * single recipient exists.
      *
@@ -70,7 +98,7 @@ class Message extends CreativeWork
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *
@@ -94,6 +122,21 @@ class Message extends CreativeWork
     public function sender($sender)
     {
         return $this->setProperty('sender', $sender);
+    }
+
+    /**
+     * A sub property of recipient. The recipient who was directly sent the
+     * message.
+     *
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $toRecipient
+     *
+     * @return static
+     *
+     * @see http://schema.org/toRecipient
+     */
+    public function toRecipient($toRecipient)
+    {
+        return $this->setProperty('toRecipient', $toRecipient);
     }
 
 }

--- a/src/MonetaryAmount.php
+++ b/src/MonetaryAmount.php
@@ -14,8 +14,15 @@ namespace Spatie\SchemaOrg;
 class MonetaryAmount extends StructuredValue
 {
     /**
-     * The currency in which the monetary amount is expressed (in 3-letter [ISO
-     * 4217](http://en.wikipedia.org/wiki/ISO_4217) format).
+     * The currency in which the monetary amount is expressed.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $currency
      *

--- a/src/NewsArticle.php
+++ b/src/NewsArticle.php
@@ -3,14 +3,31 @@
 namespace Spatie\SchemaOrg;
 
 /**
- * A news article.
+ * A NewsArticle is an article whose content reports news, or provides
+ * background context and supporting materials for understanding the news.
+ * 
+ * A more detailed overview of [schema.org News markup](/docs/news.html) is also
+ * available.
  *
  * @see http://schema.org/NewsArticle
  */
 class NewsArticle extends Article
 {
     /**
-     * The location where the NewsArticle was produced.
+     * A [dateline](https://en.wikipedia.org/wiki/Dateline) is a brief piece of
+     * text included in news articles that describes where and when the story
+     * was written or filed though the date is often omitted. Sometimes only a
+     * placename is provided.
+     * 
+     * Structured representations of dateline-related information can also be
+     * expressed more explicitly using [[locationCreated]] (which represents
+     * where a work was created e.g. where a news report was written).  For
+     * location depicted or described in the content, use [[contentLocation]].
+     * 
+     * Dateline summaries are oriented more towards human readers than towards
+     * automated processing, and can vary substantially. Some examples: "BEIRUT,
+     * Lebanon, June 2.", "Paris, France", "December 19, 2017 11:43AM Reporting
+     * from Washington", "Beijing/Moscow", "QUEZON CITY, Philippines".
      *
      * @param string|string[] $dateline
      *

--- a/src/Offer.php
+++ b/src/Offer.php
@@ -293,11 +293,11 @@ class Offer extends Intangible
     }
 
     /**
-     * The [GTIN-12](http://apps.gs1.org/GDD/glossary/Pages/GTIN-12.aspx) code
-     * of the product, or the product to which the offer refers. The GTIN-12 is
-     * the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix,
-     * Item Reference, and Check Digit used to identify trade items. See [GS1
-     * GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
+     * The GTIN-12 code of the product, or the product to which the offer
+     * refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a
+     * U.P.C. Company Prefix, Item Reference, and Check Digit used to identify
+     * trade items. See [GS1 GTIN
+     * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *
      * @param string|string[] $gtin12
@@ -312,11 +312,10 @@ class Offer extends Intangible
     }
 
     /**
-     * The [GTIN-13](http://apps.gs1.org/GDD/glossary/Pages/GTIN-13.aspx) code
-     * of the product, or the product to which the offer refers. This is
-     * equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC
-     * codes can be converted into a GTIN-13 code by simply adding a preceeding
-     * zero. See [GS1 GTIN
+     * The GTIN-13 code of the product, or the product to which the offer
+     * refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former
+     * 12-digit UPC codes can be converted into a GTIN-13 code by simply adding
+     * a preceeding zero. See [GS1 GTIN
      * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *
@@ -332,8 +331,8 @@ class Offer extends Intangible
     }
 
     /**
-     * The [GTIN-14](http://apps.gs1.org/GDD/glossary/Pages/GTIN-14.aspx) code
-     * of the product, or the product to which the offer refers. See [GS1 GTIN
+     * The GTIN-14 code of the product, or the product to which the offer
+     * refers. See [GS1 GTIN
      * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *
@@ -465,10 +464,14 @@ class Offer extends Intangible
      * 
      * Usage guidelines:
      * 
-     * * Use the [[priceCurrency]] property (with [ISO 4217
-     * codes](http://en.wikipedia.org/wiki/ISO_4217#Active_codes) e.g. "USD")
-     * instead of
-     *       including [ambiguous
+     * * Use the [[priceCurrency]] property (with standard formats: [ISO 4217
+     * currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD";
+     * [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies)
+     * for cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR") instead of including
+     * [ambiguous
      * symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign)
      * such as '$' in the value.
      * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
@@ -493,8 +496,16 @@ class Offer extends Intangible
     }
 
     /**
-     * The currency (in 3-letter ISO 4217 format) of the price or a price
-     * component, when attached to [[PriceSpecification]] and its subtypes.
+     * The currency of the price, or a price component when attached to
+     * [[PriceSpecification]] and its subtypes.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $priceCurrency
      *

--- a/src/Order.php
+++ b/src/Order.php
@@ -114,7 +114,15 @@ class Order extends Intangible
     }
 
     /**
-     * The currency (in 3-letter ISO 4217 format) of the discount.
+     * The currency of the discount.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $discountCurrency
      *

--- a/src/Organization.php
+++ b/src/Organization.php
@@ -97,6 +97,14 @@ class Organization extends Thing
      const GoodRelationsTerms = 'http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms';
 
     /**
+     * This element is based on work by the Web Applications for the Future
+     * Internet Lab, Institute of Informatics and Telematics, Pisa, Italy.
+     *
+     * @see http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it
+     */
+     const IITCNRit = 'http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it';
+
+    /**
      * This class is based on the work of the LRMI project, see lrmi.net for
      * details.
      *
@@ -135,6 +143,22 @@ class Organization extends Thing
      * @see http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_QAStackExchange
      */
      const Stack_Exchange = 'http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_QAStackExchange';
+
+    /**
+     * This term and associated definitions draws upon the work of [The Trust
+     * Project](http://thetrustproject.org/).
+     *
+     * @see https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP-draws
+     */
+     const The_Trust_Project = 'https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP-draws';
+
+    /**
+     * This element is based on the work of the [Tourism Structured Web Data
+     * Community Group](https://www.w3.org/community/tourismdata).
+     *
+     * @see http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism
+     */
+     const Tourism = 'http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism';
 
     /**
      * This class contains information contributed by
@@ -718,6 +742,30 @@ class Organization extends Thing
     public function parentOrganization($parentOrganization)
     {
         return $this->setProperty('parentOrganization', $parentOrganization);
+    }
+
+    /**
+     * The publishingPrinciples property indicates (typically via [[URL]]) a
+     * document describing the editorial principles of an [[Organization]] (or
+     * individual e.g. a [[Person]] writing a blog) that relate to their
+     * activities as a publisher, e.g. ethics or diversity policies. When
+     * applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are
+     * those of the party primarily responsible for the creation of the
+     * [[CreativeWork]].
+     * 
+     * While such policies are most typically expressed in natural language,
+     * sometimes related information (e.g. indicating a [[funder]]) can be
+     * expressed using schema.org terminology.
+     *
+     * @param CreativeWork|CreativeWork[]|string|string[] $publishingPrinciples
+     *
+     * @return static
+     *
+     * @see http://schema.org/publishingPrinciples
+     */
+    public function publishingPrinciples($publishingPrinciples)
+    {
+        return $this->setProperty('publishingPrinciples', $publishingPrinciples);
     }
 
     /**

--- a/src/PayAction.php
+++ b/src/PayAction.php
@@ -13,7 +13,7 @@ class PayAction extends TradeAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/Periodical.php
+++ b/src/Periodical.php
@@ -14,20 +14,4 @@ namespace Spatie\SchemaOrg;
  */
 class Periodical extends CreativeWorkSeries
 {
-    /**
-     * The International Standard Serial Number (ISSN) that identifies this
-     * periodical. You can repeat this property to (for example) identify
-     * different formats of this periodical.
-     *
-     * @param string|string[] $issn
-     *
-     * @return static
-     *
-     * @see http://schema.org/issn
-     */
-    public function issn($issn)
-    {
-        return $this->setProperty('issn', $issn);
-    }
-
 }

--- a/src/Person.php
+++ b/src/Person.php
@@ -629,6 +629,30 @@ class Person extends Thing
     }
 
     /**
+     * The publishingPrinciples property indicates (typically via [[URL]]) a
+     * document describing the editorial principles of an [[Organization]] (or
+     * individual e.g. a [[Person]] writing a blog) that relate to their
+     * activities as a publisher, e.g. ethics or diversity policies. When
+     * applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are
+     * those of the party primarily responsible for the creation of the
+     * [[CreativeWork]].
+     * 
+     * While such policies are most typically expressed in natural language,
+     * sometimes related information (e.g. indicating a [[funder]]) can be
+     * expressed using schema.org terminology.
+     *
+     * @param CreativeWork|CreativeWork[]|string|string[] $publishingPrinciples
+     *
+     * @return static
+     *
+     * @see http://schema.org/publishingPrinciples
+     */
+    public function publishingPrinciples($publishingPrinciples)
+    {
+        return $this->setProperty('publishingPrinciples', $publishingPrinciples);
+    }
+
+    /**
      * The most generic familial relation.
      *
      * @param Person|Person[] $relatedTo

--- a/src/Physician.php
+++ b/src/Physician.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A doctor's office.
+ *
+ * @see http://schema.org/Physician
+ */
+class Physician extends MedicalOrganization
+{
+}

--- a/src/Place.php
+++ b/src/Place.php
@@ -229,6 +229,20 @@ class Place extends Thing
     }
 
     /**
+     * A flag to signal that the item, event, or place is accessible for free.
+     *
+     * @param bool|bool[] $isAccessibleForFree
+     *
+     * @return static
+     *
+     * @see http://schema.org/isAccessibleForFree
+     */
+    public function isAccessibleForFree($isAccessibleForFree)
+    {
+        return $this->setProperty('isAccessibleForFree', $isAccessibleForFree);
+    }
+
+    /**
      * The International Standard of Industrial Classification of All Economic
      * Activities (ISIC), Revision 4 code for a particular organization,
      * business person, or place.
@@ -340,6 +354,21 @@ class Place extends Thing
     public function photos($photos)
     {
         return $this->setProperty('photos', $photos);
+    }
+
+    /**
+     * A flag to signal that the [[Place]] is open to public visitors.  If this
+     * property is omitted there is no assumed default boolean value
+     *
+     * @param bool|bool[] $publicAccess
+     *
+     * @return static
+     *
+     * @see http://schema.org/publicAccess
+     */
+    public function publicAccess($publicAccess)
+    {
+        return $this->setProperty('publicAccess', $publicAccess);
     }
 
     /**

--- a/src/PriceSpecification.php
+++ b/src/PriceSpecification.php
@@ -79,10 +79,14 @@ class PriceSpecification extends StructuredValue
      * 
      * Usage guidelines:
      * 
-     * * Use the [[priceCurrency]] property (with [ISO 4217
-     * codes](http://en.wikipedia.org/wiki/ISO_4217#Active_codes) e.g. "USD")
-     * instead of
-     *       including [ambiguous
+     * * Use the [[priceCurrency]] property (with standard formats: [ISO 4217
+     * currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD";
+     * [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies)
+     * for cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR") instead of including
+     * [ambiguous
      * symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign)
      * such as '$' in the value.
      * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
@@ -107,8 +111,16 @@ class PriceSpecification extends StructuredValue
     }
 
     /**
-     * The currency (in 3-letter ISO 4217 format) of the price or a price
-     * component, when attached to [[PriceSpecification]] and its subtypes.
+     * The currency of the price, or a price component when attached to
+     * [[PriceSpecification]] and its subtypes.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $priceCurrency
      *

--- a/src/Product.php
+++ b/src/Product.php
@@ -149,11 +149,11 @@ class Product extends Thing
     }
 
     /**
-     * The [GTIN-12](http://apps.gs1.org/GDD/glossary/Pages/GTIN-12.aspx) code
-     * of the product, or the product to which the offer refers. The GTIN-12 is
-     * the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix,
-     * Item Reference, and Check Digit used to identify trade items. See [GS1
-     * GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
+     * The GTIN-12 code of the product, or the product to which the offer
+     * refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a
+     * U.P.C. Company Prefix, Item Reference, and Check Digit used to identify
+     * trade items. See [GS1 GTIN
+     * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *
      * @param string|string[] $gtin12
@@ -168,11 +168,10 @@ class Product extends Thing
     }
 
     /**
-     * The [GTIN-13](http://apps.gs1.org/GDD/glossary/Pages/GTIN-13.aspx) code
-     * of the product, or the product to which the offer refers. This is
-     * equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC
-     * codes can be converted into a GTIN-13 code by simply adding a preceeding
-     * zero. See [GS1 GTIN
+     * The GTIN-13 code of the product, or the product to which the offer
+     * refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former
+     * 12-digit UPC codes can be converted into a GTIN-13 code by simply adding
+     * a preceeding zero. See [GS1 GTIN
      * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *
@@ -188,8 +187,8 @@ class Product extends Thing
     }
 
     /**
-     * The [GTIN-14](http://apps.gs1.org/GDD/glossary/Pages/GTIN-14.aspx) code
-     * of the product, or the product to which the offer refers. See [GS1 GTIN
+     * The GTIN-14 code of the product, or the product to which the offer
+     * refers. See [GS1 GTIN
      * Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more
      * details.
      *

--- a/src/PublicationEvent.php
+++ b/src/PublicationEvent.php
@@ -12,7 +12,7 @@ namespace Spatie\SchemaOrg;
 class PublicationEvent extends Event
 {
     /**
-     * A flag to signal that the publication or event is accessible for free.
+     * A flag to signal that the item, event, or place is accessible for free.
      *
      * @param bool|bool[] $free
      *
@@ -26,7 +26,7 @@ class PublicationEvent extends Event
     }
 
     /**
-     * A flag to signal that the publication is accessible for free.
+     * A flag to signal that the item, event, or place is accessible for free.
      *
      * @param bool|bool[] $isAccessibleForFree
      *

--- a/src/Question.php
+++ b/src/Question.php
@@ -11,11 +11,11 @@ namespace Spatie\SchemaOrg;
 class Question extends CreativeWork
 {
     /**
-     * The answer that has been accepted as best, typically on a Question/Answer
-     * site. Sites vary in their selection mechanisms, e.g. drawing on community
-     * opinion and/or the view of the Question author.
+     * The answer(s) that has been accepted as best, typically on a
+     * Question/Answer site. Sites vary in their selection mechanisms, e.g.
+     * drawing on community opinion and/or the view of the Question author.
      *
-     * @param Answer|Answer[] $acceptedAnswer
+     * @param Answer|Answer[]|ItemList|ItemList[] $acceptedAnswer
      *
      * @return static
      *
@@ -59,7 +59,7 @@ class Question extends CreativeWork
      * An answer (possibly one of several, possibly incorrect) to a Question,
      * e.g. on a Question/Answer site.
      *
-     * @param Answer|Answer[] $suggestedAnswer
+     * @param Answer|Answer[]|ItemList|ItemList[] $suggestedAnswer
      *
      * @return static
      *

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -9,7 +9,7 @@ namespace Spatie\SchemaOrg;
  *
  * @see http://schema.org/Recipe
  */
-class Recipe extends CreativeWork
+class Recipe extends HowTo
 {
     /**
      * The time it takes to actually cook the dish, in [ISO 8601 duration
@@ -69,21 +69,6 @@ class Recipe extends CreativeWork
     }
 
     /**
-     * The length of time it takes to prepare the recipe, in [ISO 8601 duration
-     * format](http://en.wikipedia.org/wiki/ISO_8601).
-     *
-     * @param Duration|Duration[] $prepTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/prepTime
-     */
-    public function prepTime($prepTime)
-    {
-        return $this->setProperty('prepTime', $prepTime);
-    }
-
-    /**
      * The category of the recipe—for example, appetizer, entree, etc.
      *
      * @param string|string[] $recipeCategory
@@ -126,9 +111,10 @@ class Recipe extends CreativeWork
     }
 
     /**
-     * A step or instruction involved in making the recipe.
+     * A step in making the recipe, in the form of a single item (document,
+     * video, etc.) or an ordered list with HowToStep and/or HowToSection items.
      *
-     * @param schema:ItemList|schema:ItemList[]|string|string[] $recipeInstructions
+     * @param CreativeWork|CreativeWork[]|ItemList|ItemList[]|string|string[] $recipeInstructions
      *
      * @return static
      *
@@ -143,7 +129,7 @@ class Recipe extends CreativeWork
      * The quantity produced by the recipe (for example, number of people
      * served, number of servings, etc).
      *
-     * @param string|string[] $recipeYield
+     * @param QuantitativeValue|QuantitativeValue[]|string|string[] $recipeYield
      *
      * @return static
      *
@@ -167,21 +153,6 @@ class Recipe extends CreativeWork
     public function suitableForDiet($suitableForDiet)
     {
         return $this->setProperty('suitableForDiet', $suitableForDiet);
-    }
-
-    /**
-     * The total time it takes to prepare and cook the recipe, in [ISO 8601
-     * duration format](http://en.wikipedia.org/wiki/ISO_8601).
-     *
-     * @param Duration|Duration[] $totalTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/totalTime
-     */
-    public function totalTime($totalTime)
-    {
-        return $this->setProperty('totalTime', $totalTime);
     }
 
 }

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -76,8 +76,16 @@ class Reservation extends Intangible
     }
 
     /**
-     * The currency (in 3-letter ISO 4217 format) of the price or a price
-     * component, when attached to [[PriceSpecification]] and its subtypes.
+     * The currency of the price, or a price component when attached to
+     * [[PriceSpecification]] and its subtypes.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $priceCurrency
      *

--- a/src/ReturnAction.php
+++ b/src/ReturnAction.php
@@ -14,7 +14,7 @@ class ReturnAction extends TransferAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1282,6 +1282,46 @@ class Schema
         return new HousePainter();
     }
 
+    public static function howTo(): HowTo
+    {
+        return new HowTo();
+    }
+
+    public static function howToDirection(): HowToDirection
+    {
+        return new HowToDirection();
+    }
+
+    public static function howToItem(): HowToItem
+    {
+        return new HowToItem();
+    }
+
+    public static function howToSection(): HowToSection
+    {
+        return new HowToSection();
+    }
+
+    public static function howToStep(): HowToStep
+    {
+        return new HowToStep();
+    }
+
+    public static function howToSupply(): HowToSupply
+    {
+        return new HowToSupply();
+    }
+
+    public static function howToTip(): HowToTip
+    {
+        return new HowToTip();
+    }
+
+    public static function howToTool(): HowToTool
+    {
+        return new HowToTool();
+    }
+
     public static function iceCreamShop(): IceCreamShop
     {
         return new IceCreamShop();
@@ -1965,6 +2005,11 @@ class Schema
     public static function photographAction(): PhotographAction
     {
         return new PhotographAction();
+    }
+
+    public static function physician(): Physician
+    {
+        return new Physician();
     }
 
     public static function place(): Place
@@ -2720,6 +2765,11 @@ class Schema
     public static function travelAgency(): TravelAgency
     {
         return new TravelAgency();
+    }
+
+    public static function trip(): Trip
+    {
+        return new Trip();
     }
 
     public static function typeAndQuantityNode(): TypeAndQuantityNode

--- a/src/SendAction.php
+++ b/src/SendAction.php
@@ -33,7 +33,7 @@ class SendAction extends TransferAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/Series.php
+++ b/src/Series.php
@@ -4,11 +4,12 @@ namespace Spatie\SchemaOrg;
 
 /**
  * A Series in schema.org is a group of related items, typically but not
- * necessarily of the same kind.
+ * necessarily of the same kind. See also [[CreativeWorkSeries]],
+ * [[EventSeries]].
  *
  * @see http://schema.org/Series
  */
-class Series extends CreativeWork
+class Series extends Intangible
 {
     /**
      * A director of e.g. tv, radio, movie, video gaming etc. content, or of an

--- a/src/ServiceChannel.php
+++ b/src/ServiceChannel.php
@@ -11,9 +11,9 @@ namespace Spatie\SchemaOrg;
 class ServiceChannel extends Intangible
 {
     /**
-     * A language someone may use with the item. Please use one of the language
-     * codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47).
-     * See also [[inLanguage]]
+     * A language someone may use with or at the item, service or place. Please
+     * use one of the language codes from the [IETF BCP 47
+     * standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]
      *
      * @param Language|Language[]|string|string[] $availableLanguage
      *

--- a/src/SingleFamilyResidence.php
+++ b/src/SingleFamilyResidence.php
@@ -11,7 +11,7 @@ class SingleFamilyResidence extends House
 {
     /**
      * The number of rooms (excluding bathrooms and closets) of the
-     * acccommodation or lodging business.
+     * accommodation or lodging business.
      * Typical unit code(s): ROM for room or C62 for no unit. The type of room
      * can be put in the unitText property of the QuantitativeValue.
      *

--- a/src/Suite.php
+++ b/src/Suite.php
@@ -35,7 +35,7 @@ class Suite extends Accommodation
 
     /**
      * The number of rooms (excluding bathrooms and closets) of the
-     * acccommodation or lodging business.
+     * accommodation or lodging business.
      * Typical unit code(s): ROM for room or C62 for no unit. The type of room
      * can be put in the unitText property of the QuantitativeValue.
      *

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -38,8 +38,16 @@ class Ticket extends Intangible
     }
 
     /**
-     * The currency (in 3-letter ISO 4217 format) of the price or a price
-     * component, when attached to [[PriceSpecification]] and its subtypes.
+     * The currency of the price, or a price component when attached to
+     * [[PriceSpecification]] and its subtypes.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
      *
      * @param string|string[] $priceCurrency
      *

--- a/src/TipAction.php
+++ b/src/TipAction.php
@@ -14,7 +14,7 @@ class TipAction extends TradeAction
      * A sub property of participant. The participant who is at the receiving
      * end of the action.
      *
-     * @param Audience|Audience[]|Organization|Organization[]|Person|Person[] $recipient
+     * @param Audience|Audience[]|ContactPoint|ContactPoint[]|Organization|Organization[]|Person|Person[] $recipient
      *
      * @return static
      *

--- a/src/TouristAttraction.php
+++ b/src/TouristAttraction.php
@@ -3,10 +3,45 @@
 namespace Spatie\SchemaOrg;
 
 /**
- * A tourist attraction.
+ * A tourist attraction.  In principle any Thing can be a [[TouristAttraction]],
+ * from a [[Mountain]] and [[LandmarksOrHistoricalBuildings]] to a
+ * [[LocalBusiness]].  This Type can be used on its own to describe a general
+ * [[TouristAttraction]], or be used as an [[additionalType]] to add tourist
+ * attraction properties to any other type.  (See examples below)
  *
  * @see http://schema.org/TouristAttraction
  */
 class TouristAttraction extends Place
 {
+    /**
+     * A language someone may use with or at the item, service or place. Please
+     * use one of the language codes from the [IETF BCP 47
+     * standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]
+     *
+     * @param Language|Language[]|string|string[] $availableLanguage
+     *
+     * @return static
+     *
+     * @see http://schema.org/availableLanguage
+     */
+    public function availableLanguage($availableLanguage)
+    {
+        return $this->setProperty('availableLanguage', $availableLanguage);
+    }
+
+    /**
+     * Attraction suitable for type(s) of tourist. eg. Children, visitors from a
+     * particular country, etc.
+     *
+     * @param Audience|Audience[]|string|string[] $touristType
+     *
+     * @return static
+     *
+     * @see http://schema.org/touristType
+     */
+    public function touristType($touristType)
+    {
+        return $this->setProperty('touristType', $touristType);
+    }
+
 }

--- a/src/TradeAction.php
+++ b/src/TradeAction.php
@@ -17,10 +17,14 @@ class TradeAction extends Action
      * 
      * Usage guidelines:
      * 
-     * * Use the [[priceCurrency]] property (with [ISO 4217
-     * codes](http://en.wikipedia.org/wiki/ISO_4217#Active_codes) e.g. "USD")
-     * instead of
-     *       including [ambiguous
+     * * Use the [[priceCurrency]] property (with standard formats: [ISO 4217
+     * currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD";
+     * [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies)
+     * for cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR") instead of including
+     * [ambiguous
      * symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign)
      * such as '$' in the value.
      * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a

--- a/src/TrainTrip.php
+++ b/src/TrainTrip.php
@@ -7,7 +7,7 @@ namespace Spatie\SchemaOrg;
  *
  * @see http://schema.org/TrainTrip
  */
-class TrainTrip extends Intangible
+class TrainTrip extends Trip
 {
     /**
      * The platform where the train arrives.
@@ -38,20 +38,6 @@ class TrainTrip extends Intangible
     }
 
     /**
-     * The expected arrival time.
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $arrivalTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/arrivalTime
-     */
-    public function arrivalTime($arrivalTime)
-    {
-        return $this->setProperty('arrivalTime', $arrivalTime);
-    }
-
-    /**
      * The platform from which the train departs.
      *
      * @param string|string[] $departurePlatform
@@ -77,36 +63,6 @@ class TrainTrip extends Intangible
     public function departureStation($departureStation)
     {
         return $this->setProperty('departureStation', $departureStation);
-    }
-
-    /**
-     * The expected departure time.
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $departureTime
-     *
-     * @return static
-     *
-     * @see http://schema.org/departureTime
-     */
-    public function departureTime($departureTime)
-    {
-        return $this->setProperty('departureTime', $departureTime);
-    }
-
-    /**
-     * The service provider, service operator, or service performer; the goods
-     * producer. Another party (a seller) may offer those services or goods on
-     * behalf of the provider. A provider may also serve as the seller.
-     *
-     * @param Organization|Organization[]|Person|Person[] $provider
-     *
-     * @return static
-     *
-     * @see http://schema.org/provider
-     */
-    public function provider($provider)
-    {
-        return $this->setProperty('provider', $provider);
     }
 
     /**

--- a/src/Trip.php
+++ b/src/Trip.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A trip or journey. An itinerary of visits to one or more places.
+ *
+ * @see http://schema.org/Trip
+ */
+class Trip extends Intangible
+{
+    /**
+     * The expected arrival time.
+     *
+     * @param \DateTimeInterface|\DateTimeInterface[] $arrivalTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/arrivalTime
+     */
+    public function arrivalTime($arrivalTime)
+    {
+        return $this->setProperty('arrivalTime', $arrivalTime);
+    }
+
+    /**
+     * The expected departure time.
+     *
+     * @param \DateTimeInterface|\DateTimeInterface[] $departureTime
+     *
+     * @return static
+     *
+     * @see http://schema.org/departureTime
+     */
+    public function departureTime($departureTime)
+    {
+        return $this->setProperty('departureTime', $departureTime);
+    }
+
+    /**
+     * An offer to provide this item&#x2014;for example, an offer to sell a
+     * product, rent the DVD of a movie, perform a service, or give away tickets
+     * to an event.
+     *
+     * @param Offer|Offer[] $offers
+     *
+     * @return static
+     *
+     * @see http://schema.org/offers
+     */
+    public function offers($offers)
+    {
+        return $this->setProperty('offers', $offers);
+    }
+
+    /**
+     * The service provider, service operator, or service performer; the goods
+     * producer. Another party (a seller) may offer those services or goods on
+     * behalf of the provider. A provider may also serve as the seller.
+     *
+     * @param Organization|Organization[]|Person|Person[] $provider
+     *
+     * @return static
+     *
+     * @see http://schema.org/provider
+     */
+    public function provider($provider)
+    {
+        return $this->setProperty('provider', $provider);
+    }
+
+}

--- a/src/UnRegisterAction.php
+++ b/src/UnRegisterAction.php
@@ -8,7 +8,7 @@ namespace Spatie\SchemaOrg;
  * Related actions:
  * 
  * * [[RegisterAction]]: antonym of UnRegisterAction.
- * * [[Leave]]: Unlike LeaveAction, UnRegisterAction implies that you are
+ * * [[LeaveAction]]: Unlike LeaveAction, UnRegisterAction implies that you are
  * unregistering from a service you werer previously registered, rather than
  * leaving a team/group of people.
  *

--- a/src/WebSite.php
+++ b/src/WebSite.php
@@ -10,4 +10,20 @@ namespace Spatie\SchemaOrg;
  */
 class WebSite extends CreativeWork
 {
+    /**
+     * The International Standard Serial Number (ISSN) that identifies this
+     * serial publication. You can repeat this property to identify different
+     * formats of, or the linking ISSN (ISSN-L) for, this serial publication.
+     *
+     * @param string|string[] $issn
+     *
+     * @return static
+     *
+     * @see http://schema.org/issn
+     */
+    public function issn($issn)
+    {
+        return $this->setProperty('issn', $issn);
+    }
+
 }


### PR DESCRIPTION
**replaces** #54 
3 commits now - cause I forgot to add the new files 🙈 😄 

The Readme says:
> The code in src is generated from Schema.org's [RFDa standards file](https://github.com/schemaorg/schemaorg/blob/master/data/schema.rdfa)

The corresponding raw link would be: [**master**/data/schema.rdfa](https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/schema.rdfa)

But the Generator uses [**sdo-callisto**/data/schema.rdfa](https://raw.githubusercontent.com/schemaorg/schemaorg/sdo-callisto/data/schema.rdfa) - this file seems outdated and misses some properties and even some new types.