### PR TITLE
Convert invalid objects that have a __toString method to strings

### DIFF
--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -102,6 +102,10 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
             $property = $property->format(DateTime::ATOM);
         }
 
+        if (is_object($property) && method_exists($property, '__toString')) {
+            $property = (string) $property;
+        }
+
         if (is_object($property)) {
             throw new InvalidProperty();
         }


### PR DESCRIPTION
This resolves #64

When serializing types, we check if the object is arrayable, if it's a Type, or if it's a DateTime. This adds an additional check to see if the object implements a __toString method, and converts to string if it does.