### PR TITLE
Extensible generator (resolves #25)

### DIFF
--- a/generator/Console/GenerateCommand.php
+++ b/generator/Console/GenerateCommand.php
@@ -39,7 +39,7 @@ class GenerateCommand extends Command
         if ($input->getOption('extensions')) {
             $extensions = explode(',', $input->getOption('extensions'));
             foreach ($extensions as $extension) {
-                switch($extension) {
+                switch ($extension) {
                     case 'auto':
                         $sources['auto'] = 'https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/ext/auto/auto.rdfa';
                         break;

--- a/generator/Console/GenerateCommand.php
+++ b/generator/Console/GenerateCommand.php
@@ -16,7 +16,8 @@ class GenerateCommand extends Command
         $this
             ->setName('generate')
             ->setDescription('Generate the package code from the schema.org docs')
-            ->addOption('local', 'l', InputOption::VALUE_NONE, 'Use a cached version of the source');
+            ->addOption('local', 'l', InputOption::VALUE_NONE, 'Use a cached version of the source')
+            ->addOption('extensions', 'e', InputOption::VALUE_REQUIRED, 'Comma-separated list of Schema.org extensions to include ()');
     }
 
     /**
@@ -31,9 +32,29 @@ class GenerateCommand extends Command
 
         $generator = new PackageGenerator();
 
-        $definitions = new Definitions([
+        $sources = [
             'core' => 'https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/schema.rdfa',
-        ]);
+        ];
+
+        if ($input->getOption('extensions')) {
+            $extensions = explode(',', $input->getOption('extensions'));
+            foreach ($extensions as $extension) {
+                switch($extension) {
+                    case 'auto':
+                        $sources['auto'] = 'https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/ext/auto/auto.rdfa';
+                        break;
+                    case 'bib':
+                        $sources['bib'] = 'https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/ext/bib/bsdo-1.0.rdfa';
+                        break;
+                    case 'health-lifesci':
+                        $sources['med-health-core'] = 'https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/ext/health-lifesci/med-health-core.rdfa';
+                        $sources['physical-activity-and-exercise'] = 'https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/ext/health-lifesci/physical-activity-and-exercise.rdfa';
+                        break;
+                }
+            }
+        }
+
+        $definitions = new Definitions($sources);
 
         if (! $input->getOption('local')) {
             $definitions->preload();

--- a/generator/Definitions.php
+++ b/generator/Definitions.php
@@ -25,9 +25,14 @@ class Definitions
         }
     }
 
-    public function query(string $selector): Crawler
+    public function query(string $sourceId, string $selector): Crawler
     {
-        return (new Crawler($this->loadSource('core')))->filter($selector);
+        return (new Crawler($this->loadSource($sourceId)))->filter($selector);
+    }
+
+    public function getSourceIds(): array
+    {
+        return array_keys($this->sources);
     }
 
     protected function loadSource(string $sourceId, bool $fromCache = true): string

--- a/generator/Parser/Tasks/ParseType.php
+++ b/generator/Parser/Tasks/ParseType.php
@@ -24,7 +24,7 @@ class ParseType extends Task
         if ($subClassOf->count() > 0) {
             $type->parents = array_filter($subClassOf
                 ->each(function (Crawler $node) {
-                    $parent = $this->getText($node);
+                    $parent = str_replace('schema:', '', $this->getText($node));
 
                     return strpos($parent, ':') === false ? $parent : null;
                 }));


### PR DESCRIPTION
This PR adds an `--extensions` flag to the `generate` command which accepts a comma-separated list of any or all of the following Schema.org extensions:

- `auto`
- `bib`
- `health-lifesci`

It also modifies the `Definitions` class, the `DefinitionParser` class, and the `ParseType` class to handle multiple input sources and extension types which have a `schema:` prefix as mentioned in [this comment](https://github.com/spatie/schema-org/issues/25#issuecomment-357271591) on the original issue. I've confirmed that running the command produces the expected supplementary classes.

Please let me know if there's anything I can add to the PR to improve it in terms of code quality or tests. And thanks for considering my contribution! 