### PR TITLE
improve Unittests

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,3 +17,7 @@ checks:
         fix_identation_4spaces: true
         fix_doc_comments: true
 
+tools:
+    external_code_coverage:
+        timeout: 600
+        runs: 6

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/schema-org.svg?style=flat-square)](https://packagist.org/packages/spatie/schema-org)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Code coverage](https://scrutinizer-ci.com/g/spatie/schema-org/badges/coverage.png)](https://scrutinizer-ci.com/g/spatie/schema-org)
 [![Build Status](https://img.shields.io/travis/spatie/schema-org/master.svg?style=flat-square)](https://travis-ci.org/spatie/schema-org)
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/schema-org.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/schema-org)
 [![StyleCI](https://styleci.io/repos/74684096/shield?branch=master)](https://styleci.io/repos/74684096)

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "larapack/dd": "^1.1",
         "league/flysystem": "^1.0",
         "phpunit/phpunit": "^6.0",
+        "scrutinizer/ocular": "^1.5",
         "symfony/console": "^3.2",
         "symfony/css-selector": "^3.2",
         "symfony/dom-crawler": "^3.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,9 @@
     </testsuites>
     <filter>
         <whitelist>
-            <directory suffix=".php">src/</directory>
+            <directory suffix=".php">src/Exceptions</directory>
+            <file>./src/BaseType.php</file>
+            <file>./src/Type.php</file>
         </whitelist>
     </filter>
     <logging>

--- a/tests/AnalysisTest.php
+++ b/tests/AnalysisTest.php
@@ -9,7 +9,7 @@ class AnalysisTest extends TestCase
 {
     use AnalysisTrait;
 
-    public function getPaths()
+    protected function getPaths()
     {
         return [
             __DIR__.'/../src',

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -233,12 +233,16 @@ class BaseTypeTest extends TestCase
     /** @test */
     public function it_can_be_json_serialized()
     {
-        $type = new DummyType();
         $child = new DummyType();
         $child->setProperty('bar', 'baz');
 
+        $type = new DummyType();
         $type->setProperty('foo', 'bar');
         $type->setProperty('child', $child);
+        $type->setProperty('array', [
+          'child' => $child,
+          'hello' => 'world',
+        ]);
 
         $expected = [
             '@context' => 'https://schema.org',
@@ -248,10 +252,29 @@ class BaseTypeTest extends TestCase
                 '@type' => 'DummyType',
                 'bar' => 'baz',
             ],
+            'array' => [
+              'child' => [
+                  '@type' => 'DummyType',
+                  'bar' => 'baz',
+              ],
+              'hello' => 'world',
+            ],
         ];
 
         $this->assertEquals($expected, $type->jsonSerialize(), 'Return value of `jsonSerialize` is wrong');
         $this->assertEquals(json_encode($expected), json_encode($type), 'JSON representation is wrong');
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\SchemaOrg\Exceptions\InvalidProperty
+     */
+    public function it_will_throw_invalid_property_exception_with_object_property()
+    {
+        $type = new DummyType();
+        $type->setProperty('foo', new class() {});
+
+        $type->jsonSerialize();
     }
 }
 

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -276,6 +276,20 @@ class BaseTypeTest extends TestCase
 
         $type->jsonSerialize();
     }
+
+    /** @test */
+    public function it_can_be_casted_to_string()
+    {
+        $type = new DummyType();
+
+        $type->setProperty('foo', 'bar');
+
+        $expected = '<script type="application/ld+json">'.
+            '{"@context":"https:\/\/schema.org","@type":"DummyType","foo":"bar"}'.
+        '</script>';
+
+        $this->assertEquals($expected, (string) $type);
+    }
 }
 
 class DummyType extends BaseType

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -272,7 +272,8 @@ class BaseTypeTest extends TestCase
     public function it_will_throw_invalid_property_exception_with_object_property()
     {
         $type = new DummyType();
-        $type->setProperty('foo', new class() {});
+        $type->setProperty('foo', new class() {
+        });
 
         $type->jsonSerialize();
     }


### PR DESCRIPTION
This will add missing unittests and exclude dynamic generated type classes from code coverage.

If #65 is merged I will add the test for `__toString` - if not done already in mentioned PR.