### PR TITLE
Update BaseType to serialize Identifier property to '@id' in order conform to LD-JSON specification

### DIFF
--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -79,6 +79,7 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
 
     public function toArray(): array
     {
+        $this->serializeIdentifier();
         $properties = $this->serializeProperty($this->getProperties());
 
         return [
@@ -111,6 +112,16 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
         }
 
         return $property;
+    }
+
+    protected function serializeIdentifier()
+    {
+        if ($this->offsetExists('identifier'))
+        {
+            $id = $this->getProperty('identifier');
+            $this->setProperty('@id', $id);
+            $this->offsetUnset('identifier');
+        }
     }
 
     public function toScript(): string

--- a/src/AMRadioChannel.php
+++ b/src/AMRadioChannel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A radio channel that uses AM.
+ *
+ * @see http://schema.org/AMRadioChannel
+ *
+ * @mixin \Spatie\SchemaOrg\RadioChannel
+ */
+class AMRadioChannel extends BaseType
+{
+}

--- a/src/ActionAccessSpecification.php
+++ b/src/ActionAccessSpecification.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A set of requirements that a must be fulfilled in order to perform an Action.
+ *
+ * @see http://schema.org/ActionAccessSpecification
+ *
+ * @mixin \Spatie\SchemaOrg\Intangible
+ */
+class ActionAccessSpecification extends BaseType
+{
+    /**
+     * 
+     *
+     * @param  $availabilityEnds
+     *
+     * @return static
+     *
+     * @see http://schema.org/availabilityEnds
+     */
+    public function availabilityEnds($availabilityEnds)
+    {
+        return $this->setProperty('availabilityEnds', $availabilityEnds);
+    }
+
+    /**
+     * 
+     *
+     * @param  $availabilityStarts
+     *
+     * @return static
+     *
+     * @see http://schema.org/availabilityStarts
+     */
+    public function availabilityStarts($availabilityStarts)
+    {
+        return $this->setProperty('availabilityStarts', $availabilityStarts);
+    }
+
+    /**
+     * 
+     *
+     * @param  $category
+     *
+     * @return static
+     *
+     * @see http://schema.org/category
+     */
+    public function category($category)
+    {
+        return $this->setProperty('category', $category);
+    }
+
+    /**
+     * 
+     *
+     * @param  $eligibleRegion
+     *
+     * @return static
+     *
+     * @see http://schema.org/eligibleRegion
+     */
+    public function eligibleRegion($eligibleRegion)
+    {
+        return $this->setProperty('eligibleRegion', $eligibleRegion);
+    }
+
+    /**
+     * 
+     *
+     * @param  $expectsAcceptanceOf
+     *
+     * @return static
+     *
+     * @see http://schema.org/expectsAcceptanceOf
+     */
+    public function expectsAcceptanceOf($expectsAcceptanceOf)
+    {
+        return $this->setProperty('expectsAcceptanceOf', $expectsAcceptanceOf);
+    }
+
+    /**
+     * 
+     *
+     * @param MediaSubscription|MediaSubscription[] $requiresSubscription
+     *
+     * @return static
+     *
+     * @see http://schema.org/requiresSubscription
+     */
+    public function requiresSubscription($requiresSubscription)
+    {
+        return $this->setProperty('requiresSubscription', $requiresSubscription);
+    }
+
+}

--- a/src/AggregateOffer.php
+++ b/src/AggregateOffer.php
@@ -15,6 +15,13 @@ class AggregateOffer extends BaseType
 {
     /**
      * The highest price of all offers available.
+     * 
+     * Usage guidelines:
+     * 
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param float|float[]|int|int[]|string|string[] $highPrice
      *
@@ -29,6 +36,13 @@ class AggregateOffer extends BaseType
 
     /**
      * The lowest price of all offers available.
+     * 
+     * Usage guidelines:
+     * 
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param float|float[]|int|int[]|string|string[] $lowPrice
      *

--- a/src/Article.php
+++ b/src/Article.php
@@ -89,6 +89,45 @@ class Article extends BaseType
     }
 
     /**
+     * Indicates sections of a Web page that are particularly 'speakable' in the
+     * sense of being highlighted as being especially appropriate for
+     * text-to-speech conversion. Other sections of a page may also be usefully
+     * spoken in particular circumstances; the 'speakable' property serves to
+     * indicate the parts most likely to be generally useful for speech.
+     * 
+     * The *speakable* property can be repeated an arbitrary number of times,
+     * with three kinds of possible 'content-locator' values:
+     * 
+     * 1.) *id-value* URL references - uses *id-value* of an element in the page
+     * being annotated. The simplest use of *speakable* has (potentially
+     * relative) URL values, referencing identified sections of the document
+     * concerned.
+     * 
+     * 2.) CSS Selectors - addresses content in the annotated page, eg. via
+     * class attribute. Use the [[cssSelector]] property.
+     * 
+     * 3.)  XPaths - addresses content via XPaths (assuming an XML view of the
+     * content). Use the [[xpath]] property.
+     * 
+     * 
+     * For more sophisticated markup of speakable sections beyond simple ID
+     * references, either CSS selectors or XPath expressions to pick out
+     * document section(s) as speakable. For this
+     * we define a supporting type, [[SpeakableSpecification]]  which is defined
+     * to be a possible value of the *speakable* property.
+     *
+     * @param SpeakableSpecification|SpeakableSpecification[]|string|string[] $speakable
+     *
+     * @return static
+     *
+     * @see http://schema.org/speakable
+     */
+    public function speakable($speakable)
+    {
+        return $this->setProperty('speakable', $speakable);
+    }
+
+    /**
      * The number of words in the text of the Article.
      *
      * @param int|int[] $wordCount

--- a/src/AudioObject.php
+++ b/src/AudioObject.php
@@ -12,6 +12,22 @@ namespace Spatie\SchemaOrg;
 class AudioObject extends BaseType
 {
     /**
+     * The caption for this object. For downloadable machine formats (closed
+     * caption, subtitles etc.) use MediaObject and indicate the
+     * [[encodingFormat]].
+     *
+     * @param MediaObject|MediaObject[]|string|string[] $caption
+     *
+     * @return static
+     *
+     * @see http://schema.org/caption
+     */
+    public function caption($caption)
+    {
+        return $this->setProperty('caption', $caption);
+    }
+
+    /**
      * If this MediaObject is an AudioObject or VideoObject, the transcript of
      * that object.
      *

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -79,6 +79,7 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
 
     public function toArray(): array
     {
+        $this->serializeIdentifier();
         $properties = $this->serializeProperty($this->getProperties());
 
         return [
@@ -111,6 +112,16 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
         }
 
         return $property;
+    }
+
+    protected function serializeIdentifier()
+    {
+        if ($this->offsetExists('identifier'))
+        {
+            $id = $this->getProperty('identifier');
+            $this->setProperty('@id', $id);
+            $this->offsetUnset('identifier');
+        }
     }
 
     public function toScript(): string

--- a/src/BedType.php
+++ b/src/BedType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A type of bed. This is used for indicating the bed or beds available in an
+ * accommodation.
+ *
+ * @see http://schema.org/BedType
+ *
+ * @mixin \Spatie\SchemaOrg\QualitativeValue
+ */
+class BedType extends BaseType
+{
+}

--- a/src/Brand.php
+++ b/src/Brand.php
@@ -55,4 +55,18 @@ class Brand extends BaseType
         return $this->setProperty('review', $review);
     }
 
+    /**
+     * A slogan or motto associated with the item.
+     *
+     * @param string|string[] $slogan
+     *
+     * @return static
+     *
+     * @see http://schema.org/slogan
+     */
+    public function slogan($slogan)
+    {
+        return $this->setProperty('slogan', $slogan);
+    }
+
 }

--- a/src/BroadcastChannel.php
+++ b/src/BroadcastChannel.php
@@ -27,6 +27,22 @@ class BroadcastChannel extends BaseType
     }
 
     /**
+     * The frequency used for over-the-air broadcasts. Numeric values or simple
+     * ranges e.g. 87-99. In addition a shortcut idiom is supported for
+     * frequences of AM and FM radio channels, e.g. "87 FM".
+     *
+     * @param BroadcastFrequencySpecification|BroadcastFrequencySpecification[]|string|string[] $broadcastFrequency
+     *
+     * @return static
+     *
+     * @see http://schema.org/broadcastFrequency
+     */
+    public function broadcastFrequency($broadcastFrequency)
+    {
+        return $this->setProperty('broadcastFrequency', $broadcastFrequency);
+    }
+
+    /**
      * The type of service required to have access to the channel (e.g. Standard
      * or Premium).
      *

--- a/src/BroadcastFrequencySpecification.php
+++ b/src/BroadcastFrequencySpecification.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * The frequency in MHz and the modulation used for a particular
+ * BroadcastService.
+ *
+ * @see http://schema.org/BroadcastFrequencySpecification
+ *
+ * @mixin \Spatie\SchemaOrg\Intangible
+ */
+class BroadcastFrequencySpecification extends BaseType
+{
+    /**
+     * The frequency in MHz for a particular broadcast.
+     *
+     * @param QuantitativeValue|QuantitativeValue[]|float|float[]|int|int[] $broadcastFrequencyValue
+     *
+     * @return static
+     *
+     * @see http://schema.org/broadcastFrequencyValue
+     */
+    public function broadcastFrequencyValue($broadcastFrequencyValue)
+    {
+        return $this->setProperty('broadcastFrequencyValue', $broadcastFrequencyValue);
+    }
+
+}

--- a/src/BroadcastService.php
+++ b/src/BroadcastService.php
@@ -56,6 +56,22 @@ class BroadcastService extends BaseType
     }
 
     /**
+     * The frequency used for over-the-air broadcasts. Numeric values or simple
+     * ranges e.g. 87-99. In addition a shortcut idiom is supported for
+     * frequences of AM and FM radio channels, e.g. "87 FM".
+     *
+     * @param BroadcastFrequencySpecification|BroadcastFrequencySpecification[]|string|string[] $broadcastFrequency
+     *
+     * @return static
+     *
+     * @see http://schema.org/broadcastFrequency
+     */
+    public function broadcastFrequency($broadcastFrequency)
+    {
+        return $this->setProperty('broadcastFrequency', $broadcastFrequency);
+    }
+
+    /**
      * The timezone in [ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601)
      * for which the service bases its broadcasts
      *
@@ -82,6 +98,20 @@ class BroadcastService extends BaseType
     public function broadcaster($broadcaster)
     {
         return $this->setProperty('broadcaster', $broadcaster);
+    }
+
+    /**
+     * A broadcast channel of a broadcast service.
+     *
+     * @param BroadcastChannel|BroadcastChannel[] $hasBroadcastChannel
+     *
+     * @return static
+     *
+     * @see http://schema.org/hasBroadcastChannel
+     */
+    public function hasBroadcastChannel($hasBroadcastChannel)
+    {
+        return $this->setProperty('hasBroadcastChannel', $hasBroadcastChannel);
     }
 
     /**

--- a/src/Campground.php
+++ b/src/Campground.php
@@ -3,18 +3,24 @@
 namespace Spatie\SchemaOrg;
 
 /**
- * A camping site, campsite, or campground is a place used for overnight stay in
- * the outdoors. In British English a campsite is an area, usually divided into
- * a number of pitches, where people can camp overnight using tents or camper
- * vans or caravans; this British English use of the word is synonymous with the
+ * A camping site, campsite, or [[Campground]] is a place used for overnight
+ * stay in the outdoors, typically containing individual [[CampingPitch]]
+ * locations. 
+ * 
+ * 
+ * In British English a campsite is an area, usually divided into a number of
+ * pitches, where people can camp overnight using tents or camper vans or
+ * caravans; this British English use of the word is synonymous with the
  * American English expression campground. In American English the term campsite
  * generally means an area where an individual, family, group, or military unit
- * can pitch a tent or parks a camper; a campground may contain many campsites
- * (Source: Wikipedia, the free encyclopedia, see <a
- * href="http://en.wikipedia.org/wiki/Campsite">http://en.wikipedia.org/wiki/Campsite</a>).
+ * can pitch a tent or park a camper; a campground may contain many campsites
+ * (Source: Wikipedia see
+ * [https://en.wikipedia.org/wiki/Campsite](https://en.wikipedia.org/wiki/Campsite)).
  * 
- * See also the <a href="/docs/hotels.html">dedicated document on the use of
- * schema.org for marking up hotels and other forms of accommodations</a>.
+ * 
+ * 
+ * See also the dedicated [document on the use of schema.org for marking up
+ * hotels and other forms of accommodations](/docs/hotels.html).
  *
  * @see http://schema.org/Campground
  *

--- a/src/CampingPitch.php
+++ b/src/CampingPitch.php
@@ -3,11 +3,23 @@
 namespace Spatie\SchemaOrg;
 
 /**
- * A camping pitch is an individual place for overnight stay in the outdoors,
- * typically being part of a larger camping site.
+ * A [[CampingPitch]] is an individual place for overnight stay in the outdoors,
+ * typically being part of a larger camping site, or [[Campground]].
  * 
- * See also the <a href="/docs/hotels.html">dedicated document on the use of
- * schema.org for marking up hotels and other forms of accommodations</a>.
+ *       
+ * In British English a campsite, or campground, is an area, usually divided
+ * into a number of pitches, where people can camp overnight using tents or
+ * camper vans or caravans; this British English use of the word is synonymous
+ * with the American English expression campground. In American English the term
+ * campsite generally means an area where an individual, family, group, or
+ * military unit can pitch a tent or park a camper; a campground may contain
+ * many campsites.
+ * (Source: Wikipedia see
+ * [https://en.wikipedia.org/wiki/Campsite](https://en.wikipedia.org/wiki/Campsite)).
+ * 
+ * 
+ * See also the dedicated [document on the use of schema.org for marking up
+ * hotels and other forms of accommodations](/docs/hotels.html).
  *
  * @see http://schema.org/CampingPitch
  *

--- a/src/CatholicChurch.php
+++ b/src/CatholicChurch.php
@@ -7,7 +7,7 @@ namespace Spatie\SchemaOrg;
  *
  * @see http://schema.org/CatholicChurch
  *
- * @mixin \Spatie\SchemaOrg\PlaceOfWorship
+ * @mixin \Spatie\SchemaOrg\Church
  */
 class CatholicChurch extends BaseType
 {

--- a/src/ConsumeAction.php
+++ b/src/ConsumeAction.php
@@ -12,6 +12,22 @@ namespace Spatie\SchemaOrg;
 class ConsumeAction extends BaseType
 {
     /**
+     * A set of requirements that a must be fulfilled in order to perform an
+     * Action. If more than one value is specied, fulfilling one set of
+     * requirements will allow the Action to be performed.
+     *
+     * @param ActionAccessSpecification|ActionAccessSpecification[] $actionAccessibilityRequirement
+     *
+     * @return static
+     *
+     * @see http://schema.org/actionAccessibilityRequirement
+     */
+    public function actionAccessibilityRequirement($actionAccessibilityRequirement)
+    {
+        return $this->setProperty('actionAccessibilityRequirement', $actionAccessibilityRequirement);
+    }
+
+    /**
      * An Offer which must be accepted before the user can perform the Action.
      * For example, the user may need to buy a movie before being able to watch
      * it.

--- a/src/CreativeWork.php
+++ b/src/CreativeWork.php
@@ -217,7 +217,7 @@ class CreativeWork extends BaseType
     /**
      * An embedded audio object.
      *
-     * @param AudioObject|AudioObject[] $audio
+     * @param AudioObject|AudioObject[]|Clip|Clip[] $audio
      *
      * @return static
      *
@@ -1118,6 +1118,22 @@ class CreativeWork extends BaseType
     }
 
     /**
+     * The "spatial" property can be used in cases when more specific properties
+     * (e.g. [[locationCreated]], [[spatialCoverage]], [[contentLocation]]) are
+     * not known to be appropriate.
+     *
+     * @param Place|Place[] $spatial
+     *
+     * @return static
+     *
+     * @see http://schema.org/spatial
+     */
+    public function spatial($spatial)
+    {
+        return $this->setProperty('spatial', $spatial);
+    }
+
+    /**
      * The spatialCoverage of a CreativeWork indicates the place(s) which are
      * the focus of the content. It is a subproperty of
      *       contentLocation intended primarily for more technical and detailed
@@ -1150,6 +1166,23 @@ class CreativeWork extends BaseType
     public function sponsor($sponsor)
     {
         return $this->setProperty('sponsor', $sponsor);
+    }
+
+    /**
+     * The "temporal" property can be used in cases where more specific
+     * properties
+     * (e.g. [[temporalCoverage]], [[dateCreated]], [[dateModified]],
+     * [[datePublished]]) are not known to be appropriate.
+     *
+     * @param \DateTimeInterface|\DateTimeInterface[]|string|string[] $temporal
+     *
+     * @return static
+     *
+     * @see http://schema.org/temporal
+     */
+    public function temporal($temporal)
+    {
+        return $this->setProperty('temporal', $temporal);
     }
 
     /**
@@ -1212,8 +1245,8 @@ class CreativeWork extends BaseType
 
     /**
      * Approximate or typical time it takes to work with or through this
-     * learning resource for the typical intended target audience, e.g. 'P30M',
-     * 'P1H25M'.
+     * learning resource for the typical intended target audience, e.g. 'PT30M',
+     * 'PT1H25M'.
      *
      * @param Duration|Duration[] $timeRequired
      *
@@ -1273,7 +1306,7 @@ class CreativeWork extends BaseType
     /**
      * An embedded video object.
      *
-     * @param VideoObject|VideoObject[] $video
+     * @param Clip|Clip[]|VideoObject|VideoObject[] $video
      *
      * @return static
      *

--- a/src/Dataset.php
+++ b/src/Dataset.php
@@ -100,34 +100,4 @@ class Dataset extends BaseType
         return $this->setProperty('issn', $issn);
     }
 
-    /**
-     * The range of spatial applicability of a dataset, e.g. for a dataset of
-     * New York weather, the state of New York.
-     *
-     * @param Place|Place[] $spatial
-     *
-     * @return static
-     *
-     * @see http://schema.org/spatial
-     */
-    public function spatial($spatial)
-    {
-        return $this->setProperty('spatial', $spatial);
-    }
-
-    /**
-     * The range of temporal applicability of a dataset, e.g. for a 2011 census
-     * dataset, the year 2011 (in ISO 8601 time interval format).
-     *
-     * @param \DateTimeInterface|\DateTimeInterface[] $temporal
-     *
-     * @return static
-     *
-     * @see http://schema.org/temporal
-     */
-    public function temporal($temporal)
-    {
-        return $this->setProperty('temporal', $temporal);
-    }
-
 }

--- a/src/Distillery.php
+++ b/src/Distillery.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A distillery.
+ *
+ * @see http://schema.org/Distillery
+ *
+ * @mixin \Spatie\SchemaOrg\FoodEstablishment
+ */
+class Distillery extends BaseType
+{
+}

--- a/src/EmployerAggregateRating.php
+++ b/src/EmployerAggregateRating.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * An aggregate rating of an Organization related to its role as an employer.
+ *
+ * @see http://schema.org/EmployerAggregateRating
+ *
+ * @mixin \Spatie\SchemaOrg\AggregateRating
+ */
+class EmployerAggregateRating extends BaseType
+{
+}

--- a/src/EndorsementRating.php
+++ b/src/EndorsementRating.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * An EndorsementRating is a rating that expresses some level of endorsement,
+ * for example inclusion in a "critic's pick" blog, a
+ * "Like" or "+1" on a social network. It can be considered the [[result]] of an
+ * [[EndorseAction]] in which the [[object]] of the action is rated positively
+ * by
+ * some [[agent]]. As is common elsewhere in schema.org, it is sometimes more
+ * useful to describe the results of such an action without explicitly
+ * describing the [[Action]].
+ * 
+ * An [[EndorsementRating]] may be part of a numeric scale or organized system,
+ * but this is not required: having an explicit type for indicating a positive,
+ * endorsement rating is particularly useful in the absence of numeric scales as
+ * it helps consumers understand that the rating is broadly positive.
+ *
+ * @see http://schema.org/EndorsementRating
+ *
+ * @mixin \Spatie\SchemaOrg\Rating
+ */
+class EndorsementRating extends BaseType
+{
+}

--- a/src/FAQPage.php
+++ b/src/FAQPage.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A [[FAQPage]] is a [[WebPage]] presenting one or more "[Frequently asked
+ * questions](https://en.wikipedia.org/wiki/FAQ)" (see also [[QAPage]]).
+ *
+ * @see http://schema.org/FAQPage
+ *
+ * @mixin \Spatie\SchemaOrg\WebPage
+ */
+class FAQPage extends BaseType
+{
+}

--- a/src/FMRadioChannel.php
+++ b/src/FMRadioChannel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A radio channel that uses FM.
+ *
+ * @see http://schema.org/FMRadioChannel
+ *
+ * @mixin \Spatie\SchemaOrg\RadioChannel
+ */
+class FMRadioChannel extends BaseType
+{
+}

--- a/src/GeoCoordinates.php
+++ b/src/GeoCoordinates.php
@@ -42,7 +42,9 @@ class GeoCoordinates extends BaseType
 
     /**
      * The elevation of a location ([WGS
-     * 84](https://en.wikipedia.org/wiki/World_Geodetic_System)).
+     * 84](https://en.wikipedia.org/wiki/World_Geodetic_System)). Values may be
+     * of the form 'NUMBER UNIT_OF_MEASUREMENT' (e.g., '1,000 m', '3,200 ft')
+     * while numbers alone should be assumed to be a value in meters.
      *
      * @param float|float[]|int|int[]|string|string[] $elevation
      *

--- a/src/GeoShape.php
+++ b/src/GeoShape.php
@@ -77,7 +77,9 @@ class GeoShape extends BaseType
 
     /**
      * The elevation of a location ([WGS
-     * 84](https://en.wikipedia.org/wiki/World_Geodetic_System)).
+     * 84](https://en.wikipedia.org/wiki/World_Geodetic_System)). Values may be
+     * of the form 'NUMBER UNIT_OF_MEASUREMENT' (e.g., '1,000 m', '3,200 ft')
+     * while numbers alone should be assumed to be a value in meters.
      *
      * @param float|float[]|int|int[]|string|string[] $elevation
      *

--- a/src/ImageObject.php
+++ b/src/ImageObject.php
@@ -12,9 +12,11 @@ namespace Spatie\SchemaOrg;
 class ImageObject extends BaseType
 {
     /**
-     * The caption for this object.
+     * The caption for this object. For downloadable machine formats (closed
+     * caption, subtitles etc.) use MediaObject and indicate the
+     * [[encodingFormat]].
      *
-     * @param string|string[] $caption
+     * @param MediaObject|MediaObject[]|string|string[] $caption
      *
      * @return static
      *

--- a/src/JobPosting.php
+++ b/src/JobPosting.php
@@ -54,7 +54,7 @@ class JobPosting extends BaseType
     }
 
     /**
-     * Educational background needed for the position.
+     * Educational background needed for the position or Occupation.
      *
      * @param string|string[] $educationRequirements
      *
@@ -83,7 +83,26 @@ class JobPosting extends BaseType
     }
 
     /**
-     * Description of skills and experience needed for the position.
+     * An estimated salary for a job posting or occupation, based on a variety
+     * of variables including, but not limited to industry, job title, and
+     * location. Estimated salaries  are often computed by outside organizations
+     * rather than the hiring organization, who may not have committed to the
+     * estimated value.
+     *
+     * @param MonetaryAmountDistribution|MonetaryAmountDistribution[] $estimatedSalary
+     *
+     * @return static
+     *
+     * @see http://schema.org/estimatedSalary
+     */
+    public function estimatedSalary($estimatedSalary)
+    {
+        return $this->setProperty('estimatedSalary', $estimatedSalary);
+    }
+
+    /**
+     * Description of skills and experience needed for the position or
+     * Occupation.
      *
      * @param string|string[] $experienceRequirements
      *
@@ -198,7 +217,7 @@ class JobPosting extends BaseType
     }
 
     /**
-     * Specific qualifications required for this role.
+     * Specific qualifications required for this role or Occupation.
      *
      * @param string|string[] $qualifications
      *
@@ -212,7 +231,21 @@ class JobPosting extends BaseType
     }
 
     /**
-     * Responsibilities associated with this role.
+     * The Occupation for the JobPosting.
+     *
+     * @param Occupation|Occupation[] $relevantOccupation
+     *
+     * @return static
+     *
+     * @see http://schema.org/relevantOccupation
+     */
+    public function relevantOccupation($relevantOccupation)
+    {
+        return $this->setProperty('relevantOccupation', $relevantOccupation);
+    }
+
+    /**
+     * Responsibilities associated with this role or Occupation.
      *
      * @param string|string[] $responsibilities
      *
@@ -242,7 +275,7 @@ class JobPosting extends BaseType
     }
 
     /**
-     * Skills required to fulfill this role.
+     * Skills required to fulfill this role or in this Occupation.
      *
      * @param string|string[] $skills
      *

--- a/src/LodgingBusiness.php
+++ b/src/LodgingBusiness.php
@@ -87,6 +87,23 @@ class LodgingBusiness extends BaseType
     }
 
     /**
+     * The number of rooms (excluding bathrooms and closets) of the
+     * accommodation or lodging business.
+     * Typical unit code(s): ROM for room or C62 for no unit. The type of room
+     * can be put in the unitText property of the QuantitativeValue.
+     *
+     * @param QuantitativeValue|QuantitativeValue[]|float|float[]|int|int[] $numberOfRooms
+     *
+     * @return static
+     *
+     * @see http://schema.org/numberOfRooms
+     */
+    public function numberOfRooms($numberOfRooms)
+    {
+        return $this->setProperty('numberOfRooms', $numberOfRooms);
+    }
+
+    /**
      * Indicates whether pets are allowed to enter the accommodation or lodging
      * business. More detailed information can be put in a text value.
      *

--- a/src/MediaSubscription.php
+++ b/src/MediaSubscription.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A subscription which allows a user to access media including audio, video,
+ * books, etc.
+ *
+ * @see http://schema.org/MediaSubscription
+ *
+ * @mixin \Spatie\SchemaOrg\Intangible
+ */
+class MediaSubscription extends BaseType
+{
+    /**
+     * The Organization responsible for authenticating the user's subscription.
+     * For example, many media apps require a cable/satellite provider to
+     * authenticate your subscription before playing media.
+     *
+     * @param Organization|Organization[] $authenticator
+     *
+     * @return static
+     *
+     * @see http://schema.org/authenticator
+     */
+    public function authenticator($authenticator)
+    {
+        return $this->setProperty('authenticator', $authenticator);
+    }
+
+    /**
+     * 
+     *
+     * @param  $expectsAcceptanceOf
+     *
+     * @return static
+     *
+     * @see http://schema.org/expectsAcceptanceOf
+     */
+    public function expectsAcceptanceOf($expectsAcceptanceOf)
+    {
+        return $this->setProperty('expectsAcceptanceOf', $expectsAcceptanceOf);
+    }
+
+}

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -12,6 +12,22 @@ namespace Spatie\SchemaOrg;
 class MenuItem extends BaseType
 {
     /**
+     * Additional menu item(s) such as a side dish of salad or side order of
+     * fries that can be added to this menu item. Additionally it can be a menu
+     * section containing allowed add-on menu items for this menu item.
+     *
+     * @param MenuItem|MenuItem[]|MenuSection|MenuSection[] $menuAddOn
+     *
+     * @return static
+     *
+     * @see http://schema.org/menuAddOn
+     */
+    public function menuAddOn($menuAddOn)
+    {
+        return $this->setProperty('menuAddOn', $menuAddOn);
+    }
+
+    /**
      * Nutrition information about the recipe or menu item.
      *
      * @param NutritionInformation|NutritionInformation[] $nutrition

--- a/src/MonetaryAmount.php
+++ b/src/MonetaryAmount.php
@@ -72,6 +72,10 @@ class MonetaryAmount extends BaseType
      * for values is 'Number'.
      * * For [[PropertyValue]], it can be 'Text;', 'Number', 'Boolean', or
      * 'StructuredValue'.
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param StructuredValue|StructuredValue[]|bool|bool[]|float|float[]|int|int[]|string|string[] $value
      *

--- a/src/MonetaryAmountDistribution.php
+++ b/src/MonetaryAmountDistribution.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A statistical distribution of monetary amounts.
+ *
+ * @see http://schema.org/MonetaryAmountDistribution
+ *
+ * @mixin \Spatie\SchemaOrg\QuantitativeValueDistribution
+ */
+class MonetaryAmountDistribution extends BaseType
+{
+    /**
+     * The currency in which the monetary amount is expressed.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
+     *
+     * @param string|string[] $currency
+     *
+     * @return static
+     *
+     * @see http://schema.org/currency
+     */
+    public function currency($currency)
+    {
+        return $this->setProperty('currency', $currency);
+    }
+
+}

--- a/src/Occupation.php
+++ b/src/Occupation.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A profession, may involve prolonged training and/or a formal qualification.
+ *
+ * @see http://schema.org/Occupation
+ *
+ * @mixin \Spatie\SchemaOrg\Intangible
+ */
+class Occupation extends BaseType
+{
+    /**
+     * Educational background needed for the position or Occupation.
+     *
+     * @param string|string[] $educationRequirements
+     *
+     * @return static
+     *
+     * @see http://schema.org/educationRequirements
+     */
+    public function educationRequirements($educationRequirements)
+    {
+        return $this->setProperty('educationRequirements', $educationRequirements);
+    }
+
+    /**
+     * An estimated salary for a job posting or occupation, based on a variety
+     * of variables including, but not limited to industry, job title, and
+     * location. Estimated salaries  are often computed by outside organizations
+     * rather than the hiring organization, who may not have committed to the
+     * estimated value.
+     *
+     * @param MonetaryAmountDistribution|MonetaryAmountDistribution[] $estimatedSalary
+     *
+     * @return static
+     *
+     * @see http://schema.org/estimatedSalary
+     */
+    public function estimatedSalary($estimatedSalary)
+    {
+        return $this->setProperty('estimatedSalary', $estimatedSalary);
+    }
+
+    /**
+     * Description of skills and experience needed for the position or
+     * Occupation.
+     *
+     * @param string|string[] $experienceRequirements
+     *
+     * @return static
+     *
+     * @see http://schema.org/experienceRequirements
+     */
+    public function experienceRequirements($experienceRequirements)
+    {
+        return $this->setProperty('experienceRequirements', $experienceRequirements);
+    }
+
+    /**
+     * The region/country for which this occupational description is
+     * appropriate. Note that educational requirements and qualifications can
+     * vary between jurisdictions.
+     *
+     * @param AdministrativeArea|AdministrativeArea[] $occupationLocation
+     *
+     * @return static
+     *
+     * @see http://schema.org/occupationLocation
+     */
+    public function occupationLocation($occupationLocation)
+    {
+        return $this->setProperty('occupationLocation', $occupationLocation);
+    }
+
+    /**
+     * Category or categories describing the job. Use BLS O*NET-SOC taxonomy:
+     * http://www.onetcenter.org/taxonomy.html. Ideally includes textual label
+     * and formal code, with the property repeated for each applicable value.
+     *
+     * @param string|string[] $occupationalCategory
+     *
+     * @return static
+     *
+     * @see http://schema.org/occupationalCategory
+     */
+    public function occupationalCategory($occupationalCategory)
+    {
+        return $this->setProperty('occupationalCategory', $occupationalCategory);
+    }
+
+    /**
+     * Specific qualifications required for this role or Occupation.
+     *
+     * @param string|string[] $qualifications
+     *
+     * @return static
+     *
+     * @see http://schema.org/qualifications
+     */
+    public function qualifications($qualifications)
+    {
+        return $this->setProperty('qualifications', $qualifications);
+    }
+
+    /**
+     * Responsibilities associated with this role or Occupation.
+     *
+     * @param string|string[] $responsibilities
+     *
+     * @return static
+     *
+     * @see http://schema.org/responsibilities
+     */
+    public function responsibilities($responsibilities)
+    {
+        return $this->setProperty('responsibilities', $responsibilities);
+    }
+
+    /**
+     * Skills required to fulfill this role or in this Occupation.
+     *
+     * @param string|string[] $skills
+     *
+     * @return static
+     *
+     * @see http://schema.org/skills
+     */
+    public function skills($skills)
+    {
+        return $this->setProperty('skills', $skills);
+    }
+
+}

--- a/src/Order.php
+++ b/src/Order.php
@@ -224,7 +224,7 @@ class Order extends BaseType
     /**
      * The item ordered.
      *
-     * @param OrderItem|OrderItem[]|Product|Product[] $orderedItem
+     * @param OrderItem|OrderItem[]|Product|Product[]|Service|Service[] $orderedItem
      *
      * @return static
      *

--- a/src/OrderItem.php
+++ b/src/OrderItem.php
@@ -72,7 +72,7 @@ class OrderItem extends BaseType
     /**
      * The item ordered.
      *
-     * @param OrderItem|OrderItem[]|Product|Product[] $orderedItem
+     * @param OrderItem|OrderItem[]|Product|Product[]|Service|Service[] $orderedItem
      *
      * @return static
      *

--- a/src/Organization.php
+++ b/src/Organization.php
@@ -828,6 +828,20 @@ class Organization extends BaseType
     }
 
     /**
+     * A slogan or motto associated with the item.
+     *
+     * @param string|string[] $slogan
+     *
+     * @return static
+     *
+     * @see http://schema.org/slogan
+     */
+    public function slogan($slogan)
+    {
+        return $this->setProperty('slogan', $slogan);
+    }
+
+    /**
      * A person or organization that supports a thing through a pledge, promise,
      * or financial contribution. e.g. a sponsor of a Medical Study or a
      * corporate sponsor of an event.

--- a/src/Person.php
+++ b/src/Person.php
@@ -373,6 +373,21 @@ class Person extends BaseType
     }
 
     /**
+     * The Person's occupation. For past professions, use Role for expressing
+     * dates.
+     *
+     * @param Occupation|Occupation[] $hasOccupation
+     *
+     * @return static
+     *
+     * @see http://schema.org/hasOccupation
+     */
+    public function hasOccupation($hasOccupation)
+    {
+        return $this->setProperty('hasOccupation', $hasOccupation);
+    }
+
+    /**
      * Indicates an OfferCatalog listing for this Organization, Person, or
      * Service.
      *

--- a/src/Place.php
+++ b/src/Place.php
@@ -402,6 +402,20 @@ class Place extends BaseType
     }
 
     /**
+     * A slogan or motto associated with the item.
+     *
+     * @param string|string[] $slogan
+     *
+     * @return static
+     *
+     * @see http://schema.org/slogan
+     */
+    public function slogan($slogan)
+    {
+        return $this->setProperty('slogan', $slogan);
+    }
+
+    /**
      * Indicates whether it is allowed to smoke in the place, e.g. in the
      * restaurant, hotel or hotel room.
      *

--- a/src/PreOrderAction.php
+++ b/src/PreOrderAction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * An agent orders a (not yet released) object/product/service to be
+ * delivered/sent.
+ *
+ * @see http://schema.org/PreOrderAction
+ *
+ * @mixin \Spatie\SchemaOrg\TradeAction
+ */
+class PreOrderAction extends BaseType
+{
+}

--- a/src/Product.php
+++ b/src/Product.php
@@ -506,6 +506,20 @@ class Product extends BaseType
     }
 
     /**
+     * A slogan or motto associated with the item.
+     *
+     * @param string|string[] $slogan
+     *
+     * @return static
+     *
+     * @see http://schema.org/slogan
+     */
+    public function slogan($slogan)
+    {
+        return $this->setProperty('slogan', $slogan);
+    }
+
+    /**
      * The weight of the product or person.
      *
      * @param QuantitativeValue|QuantitativeValue[] $weight

--- a/src/PropertyValue.php
+++ b/src/PropertyValue.php
@@ -109,6 +109,10 @@ class PropertyValue extends BaseType
      * for values is 'Number'.
      * * For [[PropertyValue]], it can be 'Text;', 'Number', 'Boolean', or
      * 'StructuredValue'.
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param StructuredValue|StructuredValue[]|bool|bool[]|float|float[]|int|int[]|string|string[] $value
      *

--- a/src/PublicationIssue.php
+++ b/src/PublicationIssue.php
@@ -7,7 +7,7 @@ namespace Spatie\SchemaOrg;
  * publication volume, often numbered, usually containing a grouping of works
  * such as articles.
  * 
- * [blog
+ * See also [blog
  * post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html).
  *
  * @see http://schema.org/PublicationIssue

--- a/src/PublicationVolume.php
+++ b/src/PublicationVolume.php
@@ -7,9 +7,8 @@ namespace Spatie\SchemaOrg;
  * multi-volume work, often numbered. It may represent a time span, such as a
  * year.
  * 
- *       <br/><br/>See also <a
- * href="http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html">blog
- * post</a>.
+ * See also [blog
+ * post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html).
  *
  * @see http://schema.org/PublicationVolume
  *

--- a/src/QuantitativeValue.php
+++ b/src/QuantitativeValue.php
@@ -100,6 +100,10 @@ class QuantitativeValue extends BaseType
      * for values is 'Number'.
      * * For [[PropertyValue]], it can be 'Text;', 'Number', 'Boolean', or
      * 'StructuredValue'.
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param StructuredValue|StructuredValue[]|bool|bool[]|float|float[]|int|int[]|string|string[] $value
      *

--- a/src/QuantitativeValueDistribution.php
+++ b/src/QuantitativeValueDistribution.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A statistical distribution of values.
+ *
+ * @see http://schema.org/QuantitativeValueDistribution
+ *
+ * @mixin \Spatie\SchemaOrg\StructuredValue
+ */
+class QuantitativeValueDistribution extends BaseType
+{
+    /**
+     * The median value.
+     *
+     * @param float|float[]|int|int[] $median
+     *
+     * @return static
+     *
+     * @see http://schema.org/median
+     */
+    public function median($median)
+    {
+        return $this->setProperty('median', $median);
+    }
+
+    /**
+     * The 10th percentile value.
+     *
+     * @param float|float[]|int|int[] $percentile10
+     *
+     * @return static
+     *
+     * @see http://schema.org/percentile10
+     */
+    public function percentile10($percentile10)
+    {
+        return $this->setProperty('percentile10', $percentile10);
+    }
+
+    /**
+     * The 25th percentile value.
+     *
+     * @param float|float[]|int|int[] $percentile25
+     *
+     * @return static
+     *
+     * @see http://schema.org/percentile25
+     */
+    public function percentile25($percentile25)
+    {
+        return $this->setProperty('percentile25', $percentile25);
+    }
+
+    /**
+     * The 75th percentile value.
+     *
+     * @param float|float[]|int|int[] $percentile75
+     *
+     * @return static
+     *
+     * @see http://schema.org/percentile75
+     */
+    public function percentile75($percentile75)
+    {
+        return $this->setProperty('percentile75', $percentile75);
+    }
+
+    /**
+     * The 90th percentile value.
+     *
+     * @param float|float[]|int|int[] $percentile90
+     *
+     * @return static
+     *
+     * @see http://schema.org/percentile90
+     */
+    public function percentile90($percentile90)
+    {
+        return $this->setProperty('percentile90', $percentile90);
+    }
+
+}

--- a/src/Rating.php
+++ b/src/Rating.php
@@ -44,6 +44,13 @@ class Rating extends BaseType
 
     /**
      * The rating for the content.
+     * 
+     * Usage guidelines:
+     * 
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param float|float[]|int|int[]|string|string[] $ratingValue
      *
@@ -54,6 +61,21 @@ class Rating extends BaseType
     public function ratingValue($ratingValue)
     {
         return $this->setProperty('ratingValue', $ratingValue);
+    }
+
+    /**
+     * This Review or Rating is relevant to this part or facet of the
+     * itemReviewed.
+     *
+     * @param string|string[] $reviewAspect
+     *
+     * @return static
+     *
+     * @see http://schema.org/reviewAspect
+     */
+    public function reviewAspect($reviewAspect)
+    {
+        return $this->setProperty('reviewAspect', $reviewAspect);
     }
 
     /**

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -190,6 +190,13 @@ class Reservation extends BaseType
     /**
      * The total price for the reservation or ticket, including applicable
      * taxes, shipping, etc.
+     * 
+     * Usage guidelines:
+     * 
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param PriceSpecification|PriceSpecification[]|float|float[]|int|int[]|string|string[] $totalPrice
      *

--- a/src/Review.php
+++ b/src/Review.php
@@ -26,6 +26,21 @@ class Review extends BaseType
     }
 
     /**
+     * This Review or Rating is relevant to this part or facet of the
+     * itemReviewed.
+     *
+     * @param string|string[] $reviewAspect
+     *
+     * @return static
+     *
+     * @see http://schema.org/reviewAspect
+     */
+    public function reviewAspect($reviewAspect)
+    {
+        return $this->setProperty('reviewAspect', $reviewAspect);
+    }
+
+    /**
      * The actual body of the review.
      *
      * @param string|string[] $reviewBody

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -7,6 +7,11 @@ namespace Spatie\SchemaOrg;
  */
 class Schema
 {
+    public static function aMRadioChannel(): AMRadioChannel
+    {
+        return new AMRadioChannel();
+    }
+
     public static function aPIReference(): APIReference
     {
         return new APIReference();
@@ -40,6 +45,11 @@ class Schema
     public static function action(): Action
     {
         return new Action();
+    }
+
+    public static function actionAccessSpecification(): ActionAccessSpecification
+    {
+        return new ActionAccessSpecification();
     }
 
     public static function actionStatusType(): ActionStatusType
@@ -277,6 +287,11 @@ class Schema
         return new BedDetails();
     }
 
+    public static function bedType(): BedType
+    {
+        return new BedType();
+    }
+
     public static function befriendAction(): BefriendAction
     {
         return new BefriendAction();
@@ -370,6 +385,11 @@ class Schema
     public static function broadcastEvent(): BroadcastEvent
     {
         return new BroadcastEvent();
+    }
+
+    public static function broadcastFrequencySpecification(): BroadcastFrequencySpecification
+    {
+        return new BroadcastFrequencySpecification();
     }
 
     public static function broadcastService(): BroadcastService
@@ -857,6 +877,11 @@ class Schema
         return new Distance();
     }
 
+    public static function distillery(): Distillery
+    {
+        return new Distillery();
+    }
+
     public static function donateAction(): DonateAction
     {
         return new DonateAction();
@@ -947,6 +972,11 @@ class Schema
         return new EmployeeRole();
     }
 
+    public static function employerAggregateRating(): EmployerAggregateRating
+    {
+        return new EmployerAggregateRating();
+    }
+
     public static function employmentAgency(): EmploymentAgency
     {
         return new EmploymentAgency();
@@ -955,6 +985,11 @@ class Schema
     public static function endorseAction(): EndorseAction
     {
         return new EndorseAction();
+    }
+
+    public static function endorsementRating(): EndorsementRating
+    {
+        return new EndorsementRating();
     }
 
     public static function energy(): Energy
@@ -1020,6 +1055,16 @@ class Schema
     public static function exhibitionEvent(): ExhibitionEvent
     {
         return new ExhibitionEvent();
+    }
+
+    public static function fAQPage(): FAQPage
+    {
+        return new FAQPage();
+    }
+
+    public static function fMRadioChannel(): FMRadioChannel
+    {
+        return new FMRadioChannel();
     }
 
     public static function fastFoodRestaurant(): FastFoodRestaurant
@@ -1577,6 +1622,11 @@ class Schema
         return new MediaObject();
     }
 
+    public static function mediaSubscription(): MediaSubscription
+    {
+        return new MediaSubscription();
+    }
+
     public static function medicalOrganization(): MedicalOrganization
     {
         return new MedicalOrganization();
@@ -1630,6 +1680,11 @@ class Schema
     public static function monetaryAmount(): MonetaryAmount
     {
         return new MonetaryAmount();
+    }
+
+    public static function monetaryAmountDistribution(): MonetaryAmountDistribution
+    {
+        return new MonetaryAmountDistribution();
     }
 
     public static function mosque(): Mosque
@@ -1795,6 +1850,11 @@ class Schema
     public static function nutritionInformation(): NutritionInformation
     {
         return new NutritionInformation();
+    }
+
+    public static function occupation(): Occupation
+    {
+        return new Occupation();
     }
 
     public static function oceanBodyOfWater(): OceanBodyOfWater
@@ -2062,6 +2122,11 @@ class Schema
         return new PostalAddress();
     }
 
+    public static function preOrderAction(): PreOrderAction
+    {
+        return new PreOrderAction();
+    }
+
     public static function prependAction(): PrependAction
     {
         return new PrependAction();
@@ -2150,6 +2215,11 @@ class Schema
     public static function quantitativeValue(): QuantitativeValue
     {
         return new QuantitativeValue();
+    }
+
+    public static function quantitativeValueDistribution(): QuantitativeValueDistribution
+    {
+        return new QuantitativeValueDistribution();
     }
 
     public static function quantity(): Quantity
@@ -2505,6 +2575,11 @@ class Schema
     public static function someProducts(): SomeProducts
     {
         return new SomeProducts();
+    }
+
+    public static function speakableSpecification(): SpeakableSpecification
+    {
+        return new SpeakableSpecification();
     }
 
     public static function specialty(): Specialty
@@ -2985,6 +3060,11 @@ class Schema
     public static function winery(): Winery
     {
         return new Winery();
+    }
+
+    public static function workersUnion(): WorkersUnion
+    {
+        return new WorkersUnion();
     }
 
     public static function writeAction(): WriteAction

--- a/src/Service.php
+++ b/src/Service.php
@@ -336,4 +336,18 @@ class Service extends BaseType
         return $this->setProperty('serviceType', $serviceType);
     }
 
+    /**
+     * A slogan or motto associated with the item.
+     *
+     * @param string|string[] $slogan
+     *
+     * @return static
+     *
+     * @see http://schema.org/slogan
+     */
+    public function slogan($slogan)
+    {
+        return $this->setProperty('slogan', $slogan);
+    }
+
 }

--- a/src/SpeakableSpecification.php
+++ b/src/SpeakableSpecification.php
@@ -3,13 +3,16 @@
 namespace Spatie\SchemaOrg;
 
 /**
- * A web page element, like a table or an image.
+ * A SpeakableSpecification indicates (typically via [[xpath]] or
+ * [[cssSelector]]) sections of a document that are highlighted as particularly
+ * [[speakable]]. Instances of this type are expected to be used primarily as
+ * values of the [[speakable]] property.
  *
- * @see http://schema.org/WebPageElement
+ * @see http://schema.org/SpeakableSpecification
  *
- * @mixin \Spatie\SchemaOrg\CreativeWork
+ * @mixin \Spatie\SchemaOrg\Intangible
  */
-class WebPageElement extends BaseType
+class SpeakableSpecification extends BaseType
 {
     /**
      * A CSS selector, e.g. of a [[SpeakableSpecification]] or

--- a/src/Thing.php
+++ b/src/Thing.php
@@ -168,6 +168,20 @@ class Thing extends BaseType
     }
 
     /**
+     * A CreativeWork or Event about this Thing..
+     *
+     * @param CreativeWork|CreativeWork[]|Event|Event[] $subjectOf
+     *
+     * @return static
+     *
+     * @see http://schema.org/subjectOf
+     */
+    public function subjectOf($subjectOf)
+    {
+        return $this->setProperty('subjectOf', $subjectOf);
+    }
+
+    /**
      * URL of the item.
      *
      * @param string|string[] $url

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -108,6 +108,13 @@ class Ticket extends BaseType
     /**
      * The total price for the reservation or ticket, including applicable
      * taxes, shipping, etc.
+     * 
+     * Usage guidelines:
+     * 
+     * * Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT
+     * NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+     * * Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a
+     * decimal point. Avoid using these symbols as a readability separator.
      *
      * @param PriceSpecification|PriceSpecification[]|float|float[]|int|int[]|string|string[] $totalPrice
      *

--- a/src/TradeAction.php
+++ b/src/TradeAction.php
@@ -51,6 +51,29 @@ class TradeAction extends BaseType
     }
 
     /**
+     * The currency of the price, or a price component when attached to
+     * [[PriceSpecification]] and its subtypes.
+     * 
+     * Use standard formats: [ISO 4217 currency
+     * format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker
+     * symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for
+     * cryptocurrencies e.g. "BTC"; well known names for [Local Exchange
+     * Tradings
+     * Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system)
+     * (LETS) and other currency types e.g. "Ithaca HOUR".
+     *
+     * @param string|string[] $priceCurrency
+     *
+     * @return static
+     *
+     * @see http://schema.org/priceCurrency
+     */
+    public function priceCurrency($priceCurrency)
+    {
+        return $this->setProperty('priceCurrency', $priceCurrency);
+    }
+
+    /**
      * One or more detailed price specifications, indicating the unit price and
      * delivery or payment charges.
      *

--- a/src/VideoObject.php
+++ b/src/VideoObject.php
@@ -43,9 +43,11 @@ class VideoObject extends BaseType
     }
 
     /**
-     * The caption for this object.
+     * The caption for this object. For downloadable machine formats (closed
+     * caption, subtitles etc.) use MediaObject and indicate the
+     * [[encodingFormat]].
      *
-     * @param string|string[] $caption
+     * @param MediaObject|MediaObject[]|string|string[] $caption
      *
      * @return static
      *

--- a/src/WebPage.php
+++ b/src/WebPage.php
@@ -133,6 +133,45 @@ class WebPage extends BaseType
     }
 
     /**
+     * Indicates sections of a Web page that are particularly 'speakable' in the
+     * sense of being highlighted as being especially appropriate for
+     * text-to-speech conversion. Other sections of a page may also be usefully
+     * spoken in particular circumstances; the 'speakable' property serves to
+     * indicate the parts most likely to be generally useful for speech.
+     * 
+     * The *speakable* property can be repeated an arbitrary number of times,
+     * with three kinds of possible 'content-locator' values:
+     * 
+     * 1.) *id-value* URL references - uses *id-value* of an element in the page
+     * being annotated. The simplest use of *speakable* has (potentially
+     * relative) URL values, referencing identified sections of the document
+     * concerned.
+     * 
+     * 2.) CSS Selectors - addresses content in the annotated page, eg. via
+     * class attribute. Use the [[cssSelector]] property.
+     * 
+     * 3.)  XPaths - addresses content via XPaths (assuming an XML view of the
+     * content). Use the [[xpath]] property.
+     * 
+     * 
+     * For more sophisticated markup of speakable sections beyond simple ID
+     * references, either CSS selectors or XPath expressions to pick out
+     * document section(s) as speakable. For this
+     * we define a supporting type, [[SpeakableSpecification]]  which is defined
+     * to be a possible value of the *speakable* property.
+     *
+     * @param SpeakableSpecification|SpeakableSpecification[]|string|string[] $speakable
+     *
+     * @return static
+     *
+     * @see http://schema.org/speakable
+     */
+    public function speakable($speakable)
+    {
+        return $this->setProperty('speakable', $speakable);
+    }
+
+    /**
      * One of the domain specialities to which this web page's content applies.
      *
      * @param Specialty|Specialty[] $specialty

--- a/src/WorkersUnion.php
+++ b/src/WorkersUnion.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\SchemaOrg;
+
+/**
+ * A Workers Union (also known as a Labor Union, Labour Union, or Trade Union)
+ * is an organization that promotes the interests of its worker members by
+ * collectively bargaining with management, organizing, and political lobbying.
+ *
+ * @see http://schema.org/WorkersUnion
+ *
+ * @mixin \Spatie\SchemaOrg\Organization
+ */
+class WorkersUnion extends BaseType
+{
+}

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -164,6 +164,35 @@ class BaseTypeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_an_array_that_conforms_to_the_ld_json_spec_with_an_id_property()
+    {
+        $type = new DummyType();
+        $child1 = new DummyType();
+        $child1->setProperty('foo', 'bar');
+        $child1->setProperty('identifier', 'unique_resource_identifier_bar');
+        $child2 = new DummyType();
+        $child2->setProperty('foo', 'baz');
+        $child2->setProperty('identifier', 'unique_resource_identifier_baz');
+        $type->setProperty('children', [$child1, $child2]);
+        $expected = [
+            '@context' => 'https://schema.org',
+            '@type' => 'DummyType',
+            'children' => [
+                [
+                    '@type' => 'DummyType',
+                    '@id'   => 'unique_resource_identifier_bar',
+                    'foo' => 'bar',
+                ], [
+                    '@type' => 'DummyType',
+                    '@id'   => 'unique_resource_identifier_baz',
+                    'foo' => 'baz',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $type->toArray());
+    }
+
+    /** @test */
     public function it_can_create_an_ld_json_script_tag()
     {
         $type = new DummyType();


### PR DESCRIPTION
https://schema.org/identifier
https://schema.org/docs/datamodel.html#identifierBg

> All schema.org syntaxes already have built-in representation for URIs and URLs, e.g. ... in JSON-LD, '@id'. Generally it is preferable to use these unless there is a specific requirement to explicitly state the kind of identifier...

This solution tries to address the concerns raised by PR #72 and Issue #59 in a clean way that will not interfere the Schema generation nor require the user to "hack" in the property via `setProperty`. It does this by extending the `toArray` to serialize the "identifier" property as "@id" and remove "identifier". 

I believe this library only has the `toScript` method to print out the schema, so I am making an assumption here that it is safe to make this modification in the `toArray` method. However, as Schema.org mentions, there are other formats that also have their own URI syntax and each format's syntax should be respected.


