### PR TITLE
type class extending the parent type class instead of BaseType class

### DIFF
--- a/generator/templates/twig/Type.php.twig
+++ b/generator/templates/twig/Type.php.twig
@@ -16,7 +16,7 @@ namespace Spatie\SchemaOrg;
 {% endfor %}
 {% endif %}
  */
-class {{ type.name }} extends BaseType
+class {{ type.name }} extends {% if type.parents %}{{ type.parents|first }}{% else %}BaseType{% endif %} 
 {
 {% for constant in type.constants %}
     /**


### PR DESCRIPTION
This PR changes the `extends` class for a schema type to its parent schema type instead of `BaseType`

Let me explain with example:

Suppose we want to add a Schema type `Book` 
https://schema.org/Book

`Book` has a parent schema type of `CreativeWork`.
`Book` also has the properties from `CreativeWork`
and `CreativeWork` also has the properties from `Thing`

With this PR, we shall be able to get the properties list of `Book` with `get_object_vars()` function.

currently it returns only the properties that are specific to `Book`, but with this PR, we shall be able to get properties for `Book` that are coming from `CreativeWork` and `Thing` as well.

In case where there are more than one parent schema types, i have used the first one for this purpose.

Please note that i have not run the `composer generate` before submitting this PR as i wanted you to analyse that we are changing one line of code.

**src** shall be updated once you accept this PR and run the generator command. 

Theoretically It will not break the existing code as the new `Book` class will still have the grand grand parent as `BaseType`.

Hope it helps.




