### PR TITLE
serialize identifier to ld+json @id

### DIFF
--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -81,6 +81,7 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
 
     public function toArray(): array
     {
+        $this->serializeIdentifier();
         $properties = $this->serializeProperty($this->getProperties());
 
         return [
@@ -113,6 +114,14 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
         }
 
         return $property;
+    }
+
+    protected function serializeIdentifier()
+    {
+        if (isset($this['identifier'])) {
+            $this->setProperty('@id', $this['identifier']);
+            unset($this['identifier']);
+        }
     }
 
     public function toScript(): string

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -81,6 +81,7 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
 
     public function toArray(): array
     {
+        $this->serializeIdentifier();
         $properties = $this->serializeProperty($this->getProperties());
 
         return [
@@ -113,6 +114,14 @@ abstract class BaseType implements Type, \ArrayAccess, \JsonSerializable
         }
 
         return $property;
+    }
+
+    protected function serializeIdentifier()
+    {
+        if (isset($this['identifier'])) {
+            $this->setProperty('@id', $this['identifier']);
+            unset($this['identifier']);
+        }
     }
 
     public function toScript(): string

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -308,6 +308,23 @@ class BaseTypeTest extends TestCase
 
         $this->assertEquals($expected, (string) $type);
     }
+
+
+    /** @test */
+    public function it_replaces_identifier_with_at_id_property()
+    {
+        $type = new DummyType();
+
+        $type->setProperty('identifier', 'object#1');
+
+        $expected = [
+            '@context' => 'https://schema.org',
+            '@type' => 'DummyType',
+            '@id' => 'object#1',
+        ];
+
+        $this->assertEquals($expected, $type->toArray());
+    }
 }
 
 class DummyType extends BaseType

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -309,7 +309,6 @@ class BaseTypeTest extends TestCase
         $this->assertEquals($expected, (string) $type);
     }
 
-
     /** @test */
     public function it_replaces_identifier_with_at_id_property()
     {


### PR DESCRIPTION
fixes #98 
replaces #79 

> All schema.org syntaxes already have built-in representation for URIs and URLs, e.g. in Microdata 'itemid', in RDFa 1.1, 'resource', **in JSON-LD, '@id'**.

https://schema.org/docs/datamodel.html#identifierBg