### PR TITLE
Issue-88 - drop support for php 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "graham-campbell/analyzer": "^2.1.1",
         "league/flysystem": "^1.0",
-        "phpunit/phpunit": "^6.0|^7.0|^8.0",
+        "phpunit/phpunit": "^7.0|^8.0",
         "scrutinizer/ocular": "^1.5",
         "symfony/console": "^3.2",
         "symfony/css-selector": "^3.2",


### PR DESCRIPTION
spatie/schema-org#88 - Remove support for PHP 7.1 and PHP 7.2, which will improve Travis build times and reduce the risk of introducing bugs as changes which make use of new language features are introduced