### PR TITLE
add identifiers to graph elements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "graham-campbell/analyzer": "^2.1.1",
+        "graham-campbell/analyzer": "^2.3",
         "league/flysystem": "^1.0",
         "phpunit/phpunit": "^8.0",
         "scrutinizer/ocular": "^1.5",

--- a/generator/templates/static/Graph.php
+++ b/generator/templates/static/Graph.php
@@ -27,7 +27,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
     /**
      * This overloads all \Spatie\SchemaOrg\Schema construction methods.
      * You can call them the same like on the \Spatie\SchemaOrg\Schema class.
-     * But you can also use the extended signatures:
+     * But you can also use the extended signatures.
      *
      * Graph::organisation(): Organisation
      * Graph::organisation('spatie'): Organisation
@@ -136,7 +136,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         }
 
         // hide single one if nothing configured
-        if (!isset($this->hidden[$type])) {
+        if (! isset($this->hidden[$type])) {
             $this->hidden[$type][$identifier] = true;
 
             return $this;
@@ -162,7 +162,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         }
 
         // show single one if nothing configured
-        if (!isset($this->hidden[$type])) {
+        if (! isset($this->hidden[$type])) {
             $this->hidden[$type][$identifier] = false;
 
             return $this;
@@ -230,6 +230,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
             '@graph' => $this->serializeElement(array_values($elements)),
         ];
     }
+
     protected function serializeElement($element)
     {
         if (is_array($element)) {

--- a/generator/templates/static/Graph.php
+++ b/generator/templates/static/Graph.php
@@ -4,6 +4,7 @@ namespace Spatie\SchemaOrg;
 
 use ArrayAccess;
 use BadMethodCallException;
+use Closure;
 use JsonSerializable;
 use ReflectionClass;
 use ReflectionNamedType;
@@ -79,6 +80,15 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         }
 
         throw new BadMethodCallException(sprintf('The method "%" does not exist on class "%s".', $method, get_class($this)));
+    }
+
+    public function if(bool $condition, Closure $callback)
+    {
+        if ($condition) {
+            $callback($this);
+        }
+
+        return $this;
     }
 
     public function add(Type $schema, string $identifier = self::IDENTIFIER_DEFAULT): self

--- a/generator/templates/static/Graph.php
+++ b/generator/templates/static/Graph.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\SchemaOrg;
 
+use ArrayAccess;
 use BadMethodCallException;
+use JsonSerializable;
 use ReflectionClass;
 use ReflectionNamedType;
 use Spatie\SchemaOrg\Exceptions\InvalidType;
@@ -12,11 +14,36 @@ use Spatie\SchemaOrg\Exceptions\TypeNotInGraph;
 /**
  * @mixin \Spatie\SchemaOrg\Schema
  */
-class Graph extends BaseType
+class Graph implements Type, ArrayAccess, JsonSerializable
 {
+    public const IDENTIFIER_DEFAULT = 'default';
+
+    /** @var array */
+    protected $elements = [];
+
     /** @var array */
     protected $hidden = [];
 
+    /**
+     * This overloads all \Spatie\SchemaOrg\Schema construction methods.
+     * You can call them the same like on the \Spatie\SchemaOrg\Schema class.
+     * But you can also use the extended signatures:
+     *
+     * Graph::organisation(): Organisation
+     * Graph::organisation('spatie'): Organisation
+     * Graph::organisation(function(Organisation $organisation, Graph $graph) {}): Graph
+     * Graph::organisation('spatie', function(Organisation $organisation, Graph $graph) {}): Graph
+     *
+     * @see \Spatie\SchemaOrg\Schema
+     *
+     * @param string $method
+     * @param array $arguments
+     *
+     * @return $this|Type
+     *
+     * @throws \ReflectionException
+     * @throws \BadMethodCallException
+     */
     public function __call(string $method, array $arguments)
     {
         if (is_callable([Schema::class, $method])) {
@@ -26,10 +53,24 @@ class Graph extends BaseType
                 throw new BadMethodCallException(sprintf('The method "%" has an invalid return type which does not resolve to "%s".', $method, ReflectionNamedType::class));
             }
 
-            $schema = $this->getOrCreate($type->getName());
+            $identifier = self::IDENTIFIER_DEFAULT;
 
-            if (isset($arguments[0]) && is_callable($arguments[0])) {
-                call_user_func($arguments[0], $schema, $this);
+            if (isset($arguments[0])) {
+                if (is_string($arguments[0])) {
+                    $identifier = $arguments[0];
+
+                    if (isset($arguments[1]) && is_callable($arguments[1])) {
+                        $callback = $arguments[1];
+                    }
+                } elseif (is_callable($arguments[0])) {
+                    $callback = $arguments[0];
+                }
+            }
+
+            $schema = $this->getOrCreate($type->getName(), $identifier);
+
+            if (isset($callback)) {
+                call_user_func($callback, $schema, $this);
 
                 return $this;
             }
@@ -40,76 +81,232 @@ class Graph extends BaseType
         throw new BadMethodCallException(sprintf('The method "%" does not exist on class "%s".', $method, get_class($this)));
     }
 
-    public function add(Type $schema): self
+    public function add(Type $schema, string $identifier = self::IDENTIFIER_DEFAULT): self
     {
         $type = get_class($schema);
 
-        if ($this->has($type)) {
-            throw new TypeAlreadyInGraph(sprintf('The graph already has an item of type "%s".', $type));
+        if ($this->has($type, $identifier)) {
+            throw new TypeAlreadyInGraph(sprintf('The graph already has an item of type "%s" with identifier "%s".', $type, $identifier));
         }
 
-        return $this->set($schema);
+        return $this->set($schema, $identifier);
     }
 
-    public function has(string $type): bool
+    public function has(string $type, string $identifier = self::IDENTIFIER_DEFAULT): bool
     {
-        return $this->offsetExists($type);
+        return array_key_exists($type, $this->elements) && array_key_exists($identifier, $this->elements[$type]);
     }
 
-    public function set(Type $schema)
+    public function set(Type $schema, string $identifier = self::IDENTIFIER_DEFAULT)
     {
-        return $this->setProperty(get_class($schema), $schema);
+        $this->elements[get_class($schema)][$identifier] = $schema;
+
+        return $this;
     }
 
-    public function get(string $type): Type
+    public function get(string $type, string $identifier = self::IDENTIFIER_DEFAULT): Type
     {
-        if (! $this->has($type)) {
-            throw new TypeNotInGraph(sprintf('The graph does not have an item of type "%s".', $type));
+        if (! $this->has($type, $identifier)) {
+            throw new TypeNotInGraph(sprintf('The graph does not have an item of type "%s" with identifier "%s".', $type, $identifier));
         }
 
-        return $this->getProperty($type);
+        return $this->elements[$type][$identifier];
     }
 
-    public function getOrCreate(string $type): Type
+    public function getOrCreate(string $type, string $identifier = self::IDENTIFIER_DEFAULT): Type
     {
         if (! is_subclass_of($type, Type::class)) {
             throw new InvalidType(sprintf('The given type "%s" is not an instance of "%s".', $type, Type::class));
         }
 
-        if (! $this->has($type)) {
-            $this->set(new $type());
+        if (! $this->has($type, $identifier)) {
+            $this->set(new $type(), $identifier);
         }
 
-        return $this->get($type);
+        return $this->get($type, $identifier);
     }
 
-    public function hide(string $type): self
+    public function hide(string $type, ?string $identifier = self::IDENTIFIER_DEFAULT): self
     {
-        $this->hidden[$type] = true;
+        // hide all
+        if ($identifier === null) {
+            $this->hidden[$type] = true;
+
+            return $this;
+        }
+
+        // hide single one if nothing configured
+        if (!isset($this->hidden[$type])) {
+            $this->hidden[$type][$identifier] = true;
+
+            return $this;
+        }
+
+        // hide single one only if all are not already hidden
+        if ($this->hidden[$type] !== true) {
+            $this->hidden[$type][$identifier] = true;
+
+            return $this;
+        }
 
         return $this;
     }
 
-    public function show(string $type): self
+    public function show(string $type, ?string $identifier = self::IDENTIFIER_DEFAULT): self
     {
-        $this->hidden[$type] = false;
+        // show all
+        if ($identifier === null) {
+            $this->hidden[$type] = false;
+
+            return $this;
+        }
+
+        // show single one if nothing configured
+        if (!isset($this->hidden[$type])) {
+            $this->hidden[$type][$identifier] = false;
+
+            return $this;
+        }
+
+        // ignore if everything is shown
+        if ($this->hidden[$type] === false) {
+            return $this;
+        }
+
+        // show single one if identifier configuration exists
+        if (is_array($this->hidden[$type])) {
+            $this->hidden[$type][$identifier] = false;
+
+            return $this;
+        }
+
+        if ($this->hidden[$type] === true) {
+            $this->hidden[$type] = [];
+
+            // keep everything hidden and show only single one
+            if (isset($this->elements[$type])) {
+                foreach ($this->elements[$type] as $id => $element) {
+                    $this->hidden[$type][$id] = $id !== $identifier;
+                }
+
+                return $this;
+            }
+
+            // show single one if no elements exist
+            $this->hidden[$type][$identifier] = false;
+
+            return $this;
+        }
 
         return $this;
     }
 
     public function toArray(): array
     {
-        $properties = $this->getProperties();
+        $elements = $this->getElements();
 
-        foreach ($this->hidden as $type => $hide) {
-            if ($hide) {
-                unset($properties[$type]);
+        foreach ($this->hidden as $type => $hideAll) {
+            if (is_bool($hideAll) && $hideAll) {
+                unset($elements[$type]);
+
+                continue;
+            }
+
+            if (is_array($hideAll)) {
+                foreach ($hideAll as $identifier => $hide) {
+                    if (is_bool($hide) && $hide) {
+                        unset($elements[$type][$identifier]);
+                    }
+                }
             }
         }
 
+        $elements = array_reduce($elements, function (array $carry, array $types) {
+            return array_merge($carry, array_values($types));
+        }, []);
+
         return [
             '@context' => $this->getContext(),
-            '@graph' => $this->serializeProperty(array_values($properties)),
+            '@graph' => $this->serializeElement(array_values($elements)),
         ];
+    }
+    protected function serializeElement($element)
+    {
+        if (is_array($element)) {
+            return array_map([$this, 'serializeElement'], array_values($element));
+        }
+
+        if ($element instanceof Type) {
+            $element = $element->toArray();
+            unset($element['@context']);
+        }
+
+        return $element;
+    }
+
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+
+    public function getContext(): string
+    {
+        return 'https://schema.org';
+    }
+
+    public function toScript(): string
+    {
+        return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return $this->toScript();
+    }
+
+    protected function getTypeAndIdentifier(string $key): array
+    {
+        if (strpos($key, '.') === false) {
+            return [$key, self::IDENTIFIER_DEFAULT];
+        }
+
+        return explode('.', $key);
+    }
+
+    public function offsetExists($offset)
+    {
+        [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+
+        return $this->has($type, $identifier);
+    }
+
+    public function offsetGet($offset)
+    {
+        [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+
+        return $this->get($type, $identifier);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $identifier = $offset;
+
+        if (strpos($offset, '.') !== false) {
+            [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+        }
+
+        $this->set($value, $identifier);
+    }
+
+    public function offsetUnset($offset)
+    {
+        [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+
+        unset($this->elements[$type][$identifier]);
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
             <directory suffix=".php">src/Exceptions</directory>
             <file>./src/BaseType.php</file>
             <file>./src/Type.php</file>
+            <file>./src/Graph.php</file>
         </whitelist>
     </filter>
     <logging>

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -27,7 +27,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
     /**
      * This overloads all \Spatie\SchemaOrg\Schema construction methods.
      * You can call them the same like on the \Spatie\SchemaOrg\Schema class.
-     * But you can also use the extended signatures:
+     * But you can also use the extended signatures.
      *
      * Graph::organisation(): Organisation
      * Graph::organisation('spatie'): Organisation
@@ -136,7 +136,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         }
 
         // hide single one if nothing configured
-        if (!isset($this->hidden[$type])) {
+        if (! isset($this->hidden[$type])) {
             $this->hidden[$type][$identifier] = true;
 
             return $this;
@@ -162,7 +162,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         }
 
         // show single one if nothing configured
-        if (!isset($this->hidden[$type])) {
+        if (! isset($this->hidden[$type])) {
             $this->hidden[$type][$identifier] = false;
 
             return $this;
@@ -230,6 +230,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
             '@graph' => $this->serializeElement(array_values($elements)),
         ];
     }
+
     protected function serializeElement($element)
     {
         if (is_array($element)) {

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -4,6 +4,7 @@ namespace Spatie\SchemaOrg;
 
 use ArrayAccess;
 use BadMethodCallException;
+use Closure;
 use JsonSerializable;
 use ReflectionClass;
 use ReflectionNamedType;
@@ -79,6 +80,15 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         }
 
         throw new BadMethodCallException(sprintf('The method "%" does not exist on class "%s".', $method, get_class($this)));
+    }
+
+    public function if(bool $condition, Closure $callback)
+    {
+        if ($condition) {
+            $callback($this);
+        }
+
+        return $this;
     }
 
     public function add(Type $schema, string $identifier = self::IDENTIFIER_DEFAULT): self

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\SchemaOrg;
 
+use ArrayAccess;
 use BadMethodCallException;
+use JsonSerializable;
 use ReflectionClass;
 use ReflectionNamedType;
 use Spatie\SchemaOrg\Exceptions\InvalidType;
@@ -12,11 +14,36 @@ use Spatie\SchemaOrg\Exceptions\TypeNotInGraph;
 /**
  * @mixin \Spatie\SchemaOrg\Schema
  */
-class Graph extends BaseType
+class Graph implements Type, ArrayAccess, JsonSerializable
 {
+    public const IDENTIFIER_DEFAULT = 'default';
+
+    /** @var array */
+    protected $elements = [];
+
     /** @var array */
     protected $hidden = [];
 
+    /**
+     * This overloads all \Spatie\SchemaOrg\Schema construction methods.
+     * You can call them the same like on the \Spatie\SchemaOrg\Schema class.
+     * But you can also use the extended signatures:
+     *
+     * Graph::organisation(): Organisation
+     * Graph::organisation('spatie'): Organisation
+     * Graph::organisation(function(Organisation $organisation, Graph $graph) {}): Graph
+     * Graph::organisation('spatie', function(Organisation $organisation, Graph $graph) {}): Graph
+     *
+     * @see \Spatie\SchemaOrg\Schema
+     *
+     * @param string $method
+     * @param array $arguments
+     *
+     * @return $this|Type
+     *
+     * @throws \ReflectionException
+     * @throws \BadMethodCallException
+     */
     public function __call(string $method, array $arguments)
     {
         if (is_callable([Schema::class, $method])) {
@@ -26,10 +53,24 @@ class Graph extends BaseType
                 throw new BadMethodCallException(sprintf('The method "%" has an invalid return type which does not resolve to "%s".', $method, ReflectionNamedType::class));
             }
 
-            $schema = $this->getOrCreate($type->getName());
+            $identifier = self::IDENTIFIER_DEFAULT;
 
-            if (isset($arguments[0]) && is_callable($arguments[0])) {
-                call_user_func($arguments[0], $schema, $this);
+            if (isset($arguments[0])) {
+                if (is_string($arguments[0])) {
+                    $identifier = $arguments[0];
+
+                    if (isset($arguments[1]) && is_callable($arguments[1])) {
+                        $callback = $arguments[1];
+                    }
+                } elseif (is_callable($arguments[0])) {
+                    $callback = $arguments[0];
+                }
+            }
+
+            $schema = $this->getOrCreate($type->getName(), $identifier);
+
+            if (isset($callback)) {
+                call_user_func($callback, $schema, $this);
 
                 return $this;
             }
@@ -40,76 +81,232 @@ class Graph extends BaseType
         throw new BadMethodCallException(sprintf('The method "%" does not exist on class "%s".', $method, get_class($this)));
     }
 
-    public function add(Type $schema): self
+    public function add(Type $schema, string $identifier = self::IDENTIFIER_DEFAULT): self
     {
         $type = get_class($schema);
 
-        if ($this->has($type)) {
-            throw new TypeAlreadyInGraph(sprintf('The graph already has an item of type "%s".', $type));
+        if ($this->has($type, $identifier)) {
+            throw new TypeAlreadyInGraph(sprintf('The graph already has an item of type "%s" with identifier "%s".', $type, $identifier));
         }
 
-        return $this->set($schema);
+        return $this->set($schema, $identifier);
     }
 
-    public function has(string $type): bool
+    public function has(string $type, string $identifier = self::IDENTIFIER_DEFAULT): bool
     {
-        return $this->offsetExists($type);
+        return array_key_exists($type, $this->elements) && array_key_exists($identifier, $this->elements[$type]);
     }
 
-    public function set(Type $schema)
+    public function set(Type $schema, string $identifier = self::IDENTIFIER_DEFAULT)
     {
-        return $this->setProperty(get_class($schema), $schema);
+        $this->elements[get_class($schema)][$identifier] = $schema;
+
+        return $this;
     }
 
-    public function get(string $type): Type
+    public function get(string $type, string $identifier = self::IDENTIFIER_DEFAULT): Type
     {
-        if (! $this->has($type)) {
-            throw new TypeNotInGraph(sprintf('The graph does not have an item of type "%s".', $type));
+        if (! $this->has($type, $identifier)) {
+            throw new TypeNotInGraph(sprintf('The graph does not have an item of type "%s" with identifier "%s".', $type, $identifier));
         }
 
-        return $this->getProperty($type);
+        return $this->elements[$type][$identifier];
     }
 
-    public function getOrCreate(string $type): Type
+    public function getOrCreate(string $type, string $identifier = self::IDENTIFIER_DEFAULT): Type
     {
         if (! is_subclass_of($type, Type::class)) {
             throw new InvalidType(sprintf('The given type "%s" is not an instance of "%s".', $type, Type::class));
         }
 
-        if (! $this->has($type)) {
-            $this->set(new $type());
+        if (! $this->has($type, $identifier)) {
+            $this->set(new $type(), $identifier);
         }
 
-        return $this->get($type);
+        return $this->get($type, $identifier);
     }
 
-    public function hide(string $type): self
+    public function hide(string $type, ?string $identifier = self::IDENTIFIER_DEFAULT): self
     {
-        $this->hidden[$type] = true;
+        // hide all
+        if ($identifier === null) {
+            $this->hidden[$type] = true;
+
+            return $this;
+        }
+
+        // hide single one if nothing configured
+        if (!isset($this->hidden[$type])) {
+            $this->hidden[$type][$identifier] = true;
+
+            return $this;
+        }
+
+        // hide single one only if all are not already hidden
+        if ($this->hidden[$type] !== true) {
+            $this->hidden[$type][$identifier] = true;
+
+            return $this;
+        }
 
         return $this;
     }
 
-    public function show(string $type): self
+    public function show(string $type, ?string $identifier = self::IDENTIFIER_DEFAULT): self
     {
-        $this->hidden[$type] = false;
+        // show all
+        if ($identifier === null) {
+            $this->hidden[$type] = false;
+
+            return $this;
+        }
+
+        // show single one if nothing configured
+        if (!isset($this->hidden[$type])) {
+            $this->hidden[$type][$identifier] = false;
+
+            return $this;
+        }
+
+        // ignore if everything is shown
+        if ($this->hidden[$type] === false) {
+            return $this;
+        }
+
+        // show single one if identifier configuration exists
+        if (is_array($this->hidden[$type])) {
+            $this->hidden[$type][$identifier] = false;
+
+            return $this;
+        }
+
+        if ($this->hidden[$type] === true) {
+            $this->hidden[$type] = [];
+
+            // keep everything hidden and show only single one
+            if (isset($this->elements[$type])) {
+                foreach ($this->elements[$type] as $id => $element) {
+                    $this->hidden[$type][$id] = $id !== $identifier;
+                }
+
+                return $this;
+            }
+
+            // show single one if no elements exist
+            $this->hidden[$type][$identifier] = false;
+
+            return $this;
+        }
 
         return $this;
     }
 
     public function toArray(): array
     {
-        $properties = $this->getProperties();
+        $elements = $this->getElements();
 
-        foreach ($this->hidden as $type => $hide) {
-            if ($hide) {
-                unset($properties[$type]);
+        foreach ($this->hidden as $type => $hideAll) {
+            if (is_bool($hideAll) && $hideAll) {
+                unset($elements[$type]);
+
+                continue;
+            }
+
+            if (is_array($hideAll)) {
+                foreach ($hideAll as $identifier => $hide) {
+                    if (is_bool($hide) && $hide) {
+                        unset($elements[$type][$identifier]);
+                    }
+                }
             }
         }
 
+        $elements = array_reduce($elements, function (array $carry, array $types) {
+            return array_merge($carry, array_values($types));
+        }, []);
+
         return [
             '@context' => $this->getContext(),
-            '@graph' => $this->serializeProperty(array_values($properties)),
+            '@graph' => $this->serializeElement(array_values($elements)),
         ];
+    }
+    protected function serializeElement($element)
+    {
+        if (is_array($element)) {
+            return array_map([$this, 'serializeElement'], array_values($element));
+        }
+
+        if ($element instanceof Type) {
+            $element = $element->toArray();
+            unset($element['@context']);
+        }
+
+        return $element;
+    }
+
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+
+    public function getContext(): string
+    {
+        return 'https://schema.org';
+    }
+
+    public function toScript(): string
+    {
+        return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return $this->toScript();
+    }
+
+    protected function getTypeAndIdentifier(string $key): array
+    {
+        if (strpos($key, '.') === false) {
+            return [$key, self::IDENTIFIER_DEFAULT];
+        }
+
+        return explode('.', $key);
+    }
+
+    public function offsetExists($offset)
+    {
+        [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+
+        return $this->has($type, $identifier);
+    }
+
+    public function offsetGet($offset)
+    {
+        [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+
+        return $this->get($type, $identifier);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $identifier = $offset;
+
+        if (strpos($offset, '.') !== false) {
+            [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+        }
+
+        $this->set($value, $identifier);
+    }
+
+    public function offsetUnset($offset)
+    {
+        [$type, $identifier] = $this->getTypeAndIdentifier($offset);
+
+        unset($this->elements[$type][$identifier]);
     }
 }

--- a/tests/GraphIdentifierTest.php
+++ b/tests/GraphIdentifierTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Spatie\SchemaOrg\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Spatie\SchemaOrg\Brand;
+use Spatie\SchemaOrg\Graph;
+use Spatie\SchemaOrg\Organization;
+use Spatie\SchemaOrg\Product;
+use Spatie\SchemaOrg\Schema;
+use Spatie\SchemaOrg\Type;
+
+class GraphIdentifierTest extends TestCase
+{
+    /** @test */
+    public function it_can_manipulate_item()
+    {
+        $graph = new Graph();
+        $graph->add(Schema::organization());
+        $graph->get(Organization::class)->name('My Company');
+        $graph->get(Organization::class, Graph::IDENTIFIER_DEFAULT)->email('contact@example.com');
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_get_existing_or_new_item()
+    {
+        $graph = new Graph();
+        $graph->getOrCreate(Organization::class)->name('My Company');
+        $graph->getOrCreate(Organization::class, Graph::IDENTIFIER_DEFAULT)->email('contact@example.com');
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_link_items()
+    {
+        $graph = new Graph();
+        $graph->set(Schema::product()->brand($graph->getOrCreate(Organization::class)));
+        $graph->getOrCreate(Organization::class, Graph::IDENTIFIER_DEFAULT)->name('My Company')->email('contact@example.com');
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"},{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_hide_single_items()
+    {
+        $graph = new Graph();
+        $graph->organization('spatie')->name('spatie');
+        $graph->organization('astrotomic')->name('astrotomic');
+        $graph->hide(Organization::class, 'astrotomic');
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_hide_all_items()
+    {
+        $graph = new Graph();
+        $graph->organization('spatie')->name('spatie');
+        $graph->organization('astrotomic')->name('astrotomic');
+        $graph->hide(Organization::class, null);
+        $graph->product()->brand($graph->organization('spatie'));
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_show_all_items()
+    {
+        $graph = new Graph();
+        $graph->organization('spatie')->name('spatie');
+        $graph->organization('astrotomic')->name('astrotomic');
+        $graph->hide(Organization::class, null);
+        $graph->product()->brand($graph->organization('spatie'));
+        $graph->show(Organization::class, null);
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Organization","name":"astrotomic"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_show_single_item_if_everything_is_hidden()
+    {
+        $graph = new Graph();
+        $graph->organization('spatie')->name('spatie');
+        $graph->organization('astrotomic')->name('astrotomic');
+        $graph->hide(Organization::class, null);
+        $graph->product()->brand($graph->organization('spatie'));
+        $graph->show(Organization::class, 'spatie');
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_hide_single_item_if_everything_is_shown()
+    {
+        $graph = new Graph();
+        $graph->organization('spatie')->name('spatie');
+        $graph->organization('astrotomic')->name('astrotomic');
+        $graph->show(Organization::class, null);
+        $graph->product()->brand($graph->organization('spatie'));
+        $graph->hide(Organization::class, 'astrotomic');
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_show_single_item_if_everything_is_shown()
+    {
+        $graph = new Graph();
+        $graph->organization('spatie')->name('spatie');
+        $graph->show(Organization::class, null);
+        $graph->product()->brand($graph->organization('spatie'));
+        $graph->show(Organization::class, 'spatie');
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_show_single_item()
+    {
+        $graph = new Graph();
+        $graph->organization('spatie')->name('spatie');
+        $graph->show(Organization::class, 'spatie');
+        $graph->product()->brand($graph->organization('spatie'));
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_show_single_item_before_it_was_created()
+    {
+        $graph = new Graph();
+        $graph->hide(Organization::class, null);
+        $graph->show(Organization::class, 'spatie');
+        $graph->organization('spatie')->name('spatie');
+        $graph->product()->brand($graph->organization('spatie'));
+
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_can_be_used_as_array()
+    {
+        $graph = new Graph();
+        $graph->organization()->name('organization');
+        $graph->organization('spatie')->name('spatie');
+
+        $this->assertTrue(isset($graph[Organization::class]));
+        $this->assertTrue(isset($graph[Organization::class.'.'.Graph::IDENTIFIER_DEFAULT]));
+        $this->assertTrue(isset($graph[Organization::class.'.spatie']));
+        $this->assertFalse(isset($graph[Organization::class.'.astrotomic']));
+
+        $this->assertEquals('organization', $graph[Organization::class]['name']);
+        $this->assertEquals('organization', $graph[Organization::class.'.'.Graph::IDENTIFIER_DEFAULT]['name']);
+        $this->assertEquals('spatie', $graph[Organization::class.'.spatie']['name']);
+
+        $graph[Organization::class.'.astrotomic'] = Schema::organization()->name('astrotomic');
+        $this->assertTrue(isset($graph[Organization::class.'.astrotomic']));
+        $this->assertEquals('astrotomic', $graph[Organization::class.'.astrotomic']['name']);
+
+        unset($graph[Organization::class.'.astrotomic']);
+        $this->assertFalse(isset($graph[Organization::class.'.astrotomic']));
+
+        $graph['astrotomic'] = Schema::organization()->name('astrotomic');
+        $this->assertTrue(isset($graph[Organization::class.'.astrotomic']));
+        $this->assertEquals('astrotomic', $graph[Organization::class.'.astrotomic']['name']);
+    }
+}

--- a/tests/GraphIdentifierTest.php
+++ b/tests/GraphIdentifierTest.php
@@ -2,14 +2,10 @@
 
 namespace Spatie\SchemaOrg\Tests;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Spatie\SchemaOrg\Brand;
 use Spatie\SchemaOrg\Graph;
 use Spatie\SchemaOrg\Organization;
-use Spatie\SchemaOrg\Product;
 use Spatie\SchemaOrg\Schema;
-use Spatie\SchemaOrg\Type;
 
 class GraphIdentifierTest extends TestCase
 {

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\SchemaOrg\Tests;
 
+use BadMethodCallException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Spatie\SchemaOrg\Brand;
@@ -18,7 +19,7 @@ class GraphTest extends TestCase
     {
         $graph = new Graph();
 
-        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[]}</script>', $graph->toScript());
+        $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[]}</script>', (string) $graph);
     }
 
     /** @test */
@@ -98,7 +99,7 @@ class GraphTest extends TestCase
     public function it_forces_unique_items()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('The graph already has an item of type "%s".', Organization::class));
+        $this->expectExceptionMessage(sprintf('The graph already has an item of type "%s" with identifier "%s".', Organization::class, Graph::IDENTIFIER_DEFAULT));
 
         $graph = new Graph();
         $graph->add(Schema::organization()->name('My Company'));
@@ -109,7 +110,7 @@ class GraphTest extends TestCase
     public function it_throws_exception_if_item_does_not_exist()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('The graph does not have an item of type "%s".', Organization::class));
+        $this->expectExceptionMessage(sprintf('The graph does not have an item of type "%s" with identifier "%s".', Organization::class, Graph::IDENTIFIER_DEFAULT));
 
         $graph = new Graph();
         $graph->get(Organization::class);
@@ -183,5 +184,15 @@ class GraphTest extends TestCase
         $this->assertInstanceOf(Organization::class, $graph->organization());
         $this->assertInstanceOf(Product::class, $graph->product());
         $this->assertEquals('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","name":"My Product","brand":{"@type":"Organization","name":"My Company"}}]}</script>', $graph->toScript());
+    }
+
+    /** @test */
+    public function it_throws_exception_if_method_does_not_exist()
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage(sprintf('The method "%" does not exist on class "%s".', 'foobar', Graph::class));
+
+        $graph = new Graph();
+        $graph->foobar();
     }
 }

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -195,4 +195,19 @@ class GraphTest extends TestCase
         $graph = new Graph();
         $graph->foobar();
     }
+
+    /** @test */
+    public function it_can_do_things_conditionally()
+    {
+        $graph = new Graph();
+        $graph->if(true, function (Graph $graph) {
+            $graph->organization()->name('spatie');
+        });
+        $graph->if(false, function (Graph $graph) {
+            $graph->organization()->name('organization');
+        });
+
+        $this->assertEquals('spatie', $graph->organization()['name']);
+        $this->assertNotEquals('organization', $graph->organization()['name']);
+    }
 }


### PR DESCRIPTION
fixes #73 

In addition to the multiple instances itself this comes with two more major changes.
* the `Graph` does not extend the `BaseType` anymore - this is because they got too different and doesn't overlap enough anymore.
* the `hide()` and `show()` logic on the `Graph` got much more complex with the goal to let it do what the user (or I) would expect it to do if multiple calls with different parameters are chained.
  * `->hide(Org::class, null)->hide(Org::class, 'spatie')` won't only hide spatie but simply ignore the second call because the first one already ignores all orgs.
  * `->hide(Org::class, null)->show(Org::class, 'spatie')` is the most complex one - it will keep all existing orgs hidden except the specific spatie one.
At all the `hide()` and `show()` methods should be called after adding all instances to make this work like expected.

```php
$graph = new Graph();
$graph->organization('example1');
$graph->organization('spatie');
$graph->hide(Organization::class, null);
$graph->show(Organization::class, 'spatie'):
$graph->organization('example2');
```
Would result in two shown organizations (`spatie` & `example2`) because the last one is added after the hide all configuration is overridden by the specific hide/show configuration.

But without all this we would receive even more unexpected results. Right now there is no weighting - so simply the last call will set the state. So you should be careful in which order you hide/show your graph elements.