### PR TITLE
Empty string check when setting a property.

### DIFF
--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -26,7 +26,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
 
     public function setProperty(string $property, $value)
     {
-        if ($value !== null) {
+        if ($value !== null && $value !== '') {
             $this->properties[$property] = $value;
         }
 

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -26,7 +26,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
 
     public function setProperty(string $property, $value)
     {
-        if ($value !== null && $value !== ''){
+        if ($value !== null && $value !== '') {
             $this->properties[$property] = $value;
         }
 

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -26,7 +26,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
 
     public function setProperty(string $property, $value)
     {
-        if ($value !== null && trim($value) !== ''){
+        if ($value !== null && $value !== ''){
             $this->properties[$property] = $value;
         }
 

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -26,7 +26,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
 
     public function setProperty(string $property, $value)
     {
-        if ($value !== null) {
+        if ($value !== null && trim($value) !== ''){
             $this->properties[$property] = $value;
         }
 


### PR DESCRIPTION
Update BaseType.php
Added empty string check when setting a property.
Fixes issue #151 