### PR TITLE
Allow to set different context for graph

### DIFF
--- a/generator/templates/twig/Graph.php.twig
+++ b/generator/templates/twig/Graph.php.twig
@@ -27,6 +27,9 @@ class Graph implements Type, ArrayAccess, JsonSerializable
     /** @var array */
     protected $hidden = [];
 
+    /** @var string */
+    protected $context = 'https://schema.org';
+
     /**
      * This overloads all \Spatie\SchemaOrg\Schema construction methods.
      * You can call them the same like on the \Spatie\SchemaOrg\Schema class.
@@ -264,7 +267,14 @@ class Graph implements Type, ArrayAccess, JsonSerializable
 
     public function getContext(): string
     {
-        return 'https://schema.org';
+        return $this->context;
+    }
+
+    public function setContext(string $context): self
+    {
+        $this->context = $context;
+
+        return $this;
     }
 
     public function toScript(): string

--- a/generator/templates/twig/Graph.php.twig
+++ b/generator/templates/twig/Graph.php.twig
@@ -27,8 +27,13 @@ class Graph implements Type, ArrayAccess, JsonSerializable
     /** @var array */
     protected $hidden = [];
 
-    /** @var string */
-    protected $context = 'https://schema.org';
+    /** @var string|null */
+    protected $context;
+
+    public function __construct(?string $context = null)
+    {
+        $this->context = $context;
+    }
 
     /**
      * This overloads all \Spatie\SchemaOrg\Schema construction methods.
@@ -267,14 +272,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
 
     public function getContext(): string
     {
-        return $this->context;
-    }
-
-    public function setContext(string $context): self
-    {
-        $this->context = $context;
-
-        return $this;
+        return $this->context ?? 'https://schema.org';
     }
 
     public function toScript(): string

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -865,8 +865,13 @@ class Graph implements Type, ArrayAccess, JsonSerializable
     /** @var array */
     protected $hidden = [];
 
-    /** @var string */
-    protected $context = 'https://schema.org';
+    /** @var string|null */
+    protected $context;
+
+    public function __construct(?string $context = null)
+    {
+        $this->context = $context;
+    }
 
     /**
      * This overloads all \Spatie\SchemaOrg\Schema construction methods.
@@ -1105,14 +1110,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
 
     public function getContext(): string
     {
-        return $this->context;
-    }
-
-    public function setContext(string $context): self
-    {
-        $this->context = $context;
-
-        return $this;
+        return $this->context ?? 'https://schema.org';
     }
 
     public function toScript(): string

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -865,6 +865,9 @@ class Graph implements Type, ArrayAccess, JsonSerializable
     /** @var array */
     protected $hidden = [];
 
+    /** @var string */
+    protected $context = 'https://schema.org';
+
     /**
      * This overloads all \Spatie\SchemaOrg\Schema construction methods.
      * You can call them the same like on the \Spatie\SchemaOrg\Schema class.
@@ -1102,7 +1105,14 @@ class Graph implements Type, ArrayAccess, JsonSerializable
 
     public function getContext(): string
     {
-        return 'https://schema.org';
+        return $this->context;
+    }
+
+    public function setContext(string $context): self
+    {
+        $this->context = $context;
+
+        return $this;
     }
 
     public function toScript(): string

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -230,4 +230,13 @@ class GraphTest extends TestCase
             $graph->toScript()
         );
     }
+
+    /** @test */
+    public function it_can_change_context()
+    {
+        $graph = new Graph();
+
+        $graph->setContext('https://foobar.com');
+        $this->assertSame('https://foobar.com', $graph->getContext());
+    }
 }

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -232,11 +232,9 @@ class GraphTest extends TestCase
     }
 
     /** @test */
-    public function it_can_change_context()
+    public function it_can_be_initialized_with_different_context()
     {
-        $graph = new Graph();
-
-        $graph->setContext('https://foobar.com');
+        $graph = new Graph('https://foobar.com');
         $this->assertSame('https://foobar.com', $graph->getContext());
     }
 }


### PR DESCRIPTION
Hey there,

Excellent library! I enjoy working with it a lot.
I have a similar use case as described in https://github.com/spatie/schema-org/issues/25. I managed to write my own types by just extending `BaseType` which is enough for my use case because there's not many. However, I cannot use the `Graph` class for my own context right now which this simple PR would solve :) 