### PR TITLE
Update dependencies, refactor & generator - Future Updates [1/2]

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 7.4, 7.3]
+                php: [8.1, 8.0, 7.4]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,16 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "graham-campbell/analyzer": "^3.0.4",
-        "illuminate/collections": "^8.16.1",
-        "league/flysystem": "^1.1.3",
+        "graham-campbell/analyzer": "^3.0.5",
+        "illuminate/collections": "^8.62.0",
+        "league/flysystem": "^2.3.0",
         "phpunit/phpunit": "^9.4.3",
-        "symfony/console": "^3.4.47",
-        "twig/twig": "^1.44.1"
+        "symfony/console": "^5.3.7",
+        "twig/twig": "^3.3.3"
     },
     "config": {
         "sort-packages": true

--- a/generator/Writer/Filesystem.php
+++ b/generator/Writer/Filesystem.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\SchemaOrg\Generator\Writer;
 
-use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\Filesystem as Flysystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use Spatie\SchemaOrg\Generator\Type;
 use Spatie\SchemaOrg\Generator\TypeCollection;
 

--- a/generator/Writer/Filesystem.php
+++ b/generator/Writer/Filesystem.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\SchemaOrg\Generator\Writer;
 
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\Filesystem as Flysystem;
 use Spatie\SchemaOrg\Generator\Type;
 use Spatie\SchemaOrg\Generator\TypeCollection;
@@ -29,7 +29,7 @@ class Filesystem
 
     public function __construct(string $root)
     {
-        $adapter = new Local($root);
+        $adapter = new LocalFilesystemAdapter($root);
         $this->flysystem = new Flysystem($adapter);
 
         $this->contractTemplate = new Template('Contract.php.twig');
@@ -41,8 +41,8 @@ class Filesystem
 
     public function clear()
     {
-        $this->flysystem->deleteDir('src');
-        $this->flysystem->createDir('src');
+        $this->flysystem->deleteDirectory('src');
+        $this->flysystem->deleteDirectory('src');
     }
 
     public function cloneStaticFiles()
@@ -54,7 +54,7 @@ class Filesystem
                 continue;
             }
 
-            $this->flysystem->put(
+            $this->flysystem->write(
                 str_replace('generator/templates/static', 'src', $file['path']),
                 $this->flysystem->read($file['path'])
             );
@@ -63,12 +63,12 @@ class Filesystem
 
     public function createType(Type $type)
     {
-        $this->flysystem->put(
+        $this->flysystem->write(
             "src/Contracts/{$type->className}Contract.php",
             $this->contractTemplate->render(['type' => $type])
         );
 
-        $this->flysystem->put(
+        $this->flysystem->write(
             "src/{$type->className}.php",
             $this->typeTemplate->render(['type' => $type])
         );
@@ -76,17 +76,17 @@ class Filesystem
 
     public function createBuilderClass(TypeCollection $types)
     {
-        $this->flysystem->put(
+        $this->flysystem->write(
             'src/Schema.php',
             $this->builderClassTemplate->render(['types' => $types->toArray()])
         );
 
-        $this->flysystem->put(
+        $this->flysystem->write(
             'src/Graph.php',
             $this->graphClassTemplate->render(['types' => $types->toArray()])
         );
 
-        $this->flysystem->put(
+        $this->flysystem->write(
             'src/MultiTypedEntity.php',
             $this->multiTypedEntityClassTemplate->render(['types' => $types->toArray()])
         );

--- a/generator/Writer/Filesystem.php
+++ b/generator/Writer/Filesystem.php
@@ -42,7 +42,7 @@ class Filesystem
     public function clear()
     {
         $this->flysystem->deleteDirectory('src');
-        $this->flysystem->deleteDirectory('src');
+        $this->flysystem->createDirectory('src');
     }
 
     public function cloneStaticFiles()

--- a/generator/Writer/Template.php
+++ b/generator/Writer/Template.php
@@ -2,14 +2,13 @@
 
 namespace Spatie\SchemaOrg\Generator\Writer;
 
-use Twig_Environment;
-use Twig_Loader_Filesystem;
-use Twig_SimpleFilter;
+use Twig\Environment as TwigEnvironment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
 
 class Template
 {
-    /** @var \Twig_Environment */
-    protected $twig;
+    protected TwigEnvironment $twig;
 
     /** @var string */
     protected $template;
@@ -27,25 +26,25 @@ class Template
             ->render($context);
     }
 
-    protected function createTwigEnvironment(): Twig_Environment
+    protected function createTwigEnvironment(): TwigEnvironment
     {
-        $loader = new Twig_Loader_Filesystem(__DIR__.'/../templates/twig');
+        $loader = new FilesystemLoader(__DIR__.'/../templates/twig');
 
-        $twig = new Twig_Environment($loader, [
+        $twig = new TwigEnvironment($loader, [
             'cache' => false,
             'autoescape' => false,
         ]);
 
         $twig->addFilter(
-            new Twig_SimpleFilter('doc', [Filters::class, 'doc'], ['is_variadic' => true])
+            new TwigFilter('doc', [Filters::class, 'doc'], ['is_variadic' => true])
         );
 
         $twig->addFilter(
-            new Twig_SimpleFilter('param', [Filters::class, 'param'])
+            new TwigFilter('param', [Filters::class, 'param'])
         );
 
         $twig->addFilter(
-            new Twig_SimpleFilter('lcfirst', [Filters::class, 'lcfirst'])
+            new TwigFilter('lcfirst', [Filters::class, 'lcfirst'])
         );
 
         return $twig;

--- a/generator/templates/twig/Contract.php.twig
+++ b/generator/templates/twig/Contract.php.twig
@@ -4,8 +4,10 @@ namespace Spatie\SchemaOrg\Contracts;
 
 interface {{ type.className }}Contract
 {
-{% for property in type.properties if not property.pending  %}
+{% for property in type.properties %}
+{% if not property.pending  %}
     public function {{ property.name }}(${{ property.name }});
 
+{% endif %}
 {% endfor %}
 }

--- a/generator/templates/twig/Type.php.twig
+++ b/generator/templates/twig/Type.php.twig
@@ -18,8 +18,10 @@ use \Spatie\SchemaOrg\Contracts\{{ parent }}Contract;
  * @link {{ type.source }}
 {% endif %}
  *
-{% for property in type.properties if property.pending  %}
+{% for property in type.properties %}
+{% if property.pending %}
  * @method static {{ property.name }}(${{ property.name }}) The value should be instance of pending types {{ property.ranges | join('|') }}
+{% endif %}
 {% endfor %}
  */
 class {{ type.className }} extends BaseType implements {{ type.className }}Contract{% if type.parents %}, {% endif %}{{ type.parents|map(parent => "#{parent}Contract")|join(', ') }}
@@ -46,7 +48,8 @@ class {{ type.className }} extends BaseType implements {{ type.className }}Contr
     }
 
 {% endif %}
-{% for property in type.properties if not property.pending  %}
+{% for property in type.properties %}
+{% if not property.pending %}
     /**
      * {{ property.description | doc(1) }}
      *
@@ -67,5 +70,6 @@ class {{ type.className }} extends BaseType implements {{ type.className }}Contr
         return $this->setProperty('{{ property.name }}', ${{ property.name }});
     }
 
+{% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
This commit updates the composer deps for the generator, then it refactors the generator code for breakage.
And finally I run the generator to get the expected results of 0 actual changes to files in src.

Also, this PR bumps the 7.X version up to 7.4 as well here (and adds 8.1 tests).
Not for a particular need, but simply to get rid of EOL 7.3.

---

I also hope to send a PR to update the Schema-org version itself. However that will take more time as they changed how things are presented yet again. So now the schema itself uses the `@context` defined data a LOT more.