### PR TITLE
Update Docs for v4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All Notable changes to `schema-org` will be documented in this file.
 
+## 4.0.0 - 2021-10-?
+- Upgrade to schema.org:v10
+- Drop support for EOL PHP 7.3
+- Add support for PHP 8.1
+
 ## 3.4.0 - 2021-05-10
 
 - add custom `\Spatie\SchemaOrg\Graph` context support - [#160](https://github.com/spatie/schema-org/pull/160)

--- a/README.md
+++ b/README.md
@@ -50,13 +50,6 @@ You can install the package via composer:
 composer require spatie/schema-org
 ```
 
-### Supported Schema Versions
-| Package Version | Schema Version |
-|-----------------|----------------|
-| 3.x.x           | V9             |
-| 4.x.x           | V10            |
-
-Note: Only lists _current_ versions of the spatie/schema-org package.
 ## Usage
 
 All types can be instantiated through the `Spatie\SchemaOrg\Schema` factory class, or with the `new` keyword.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ You can install the package via composer:
 composer require spatie/schema-org
 ```
 
+### Supported Schema Versions
+| Package Version | Schema Version |
+|-----------------|----------------|
+| 3.x.x           | V9             |
+| 4.x.x           | V10            |
+
+Note: Only lists _current_ versions of the spatie/schema-org package.
 ## Usage
 
 All types can be instantiated through the `Spatie\SchemaOrg\Schema` factory class, or with the `new` keyword.


### PR DESCRIPTION
This is just a minor PR to help with a release for the Schema V10 based release.
From what I see past releases increment major version for Schema source changes.
So going with that this should be V4, unless you want to go with a different strategy.

---

Note: the date will just need updating before tagging a release.