### PR TITLE
Add PHP 8.1 type hints to ArrayAccess and JsonSerializable

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.0, 7.4]
+                php: [8.1, 8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -69,22 +69,22 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return new ReferencedType($this);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return array_key_exists($offset, $this->properties);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->getProperty($offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->setProperty($offset, $value);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->properties[$offset]);
     }

--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -142,7 +142,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -74,8 +74,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return array_key_exists($offset, $this->properties);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getProperty($offset);
     }
@@ -143,8 +142,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -69,22 +69,23 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return new ReferencedType($this);
     }
 
-    public function offsetExists(mixed $offset): bool
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->properties);
     }
 
-    public function offsetGet(mixed $offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         return $this->getProperty($offset);
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetSet($offset, $value): void
     {
         $this->setProperty($offset, $value);
     }
 
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset($offset): void
     {
         unset($this->properties[$offset]);
     }
@@ -142,7 +143,8 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/generator/templates/static/ReferencedType.php
+++ b/generator/templates/static/ReferencedType.php
@@ -26,7 +26,7 @@ class ReferencedType implements Type, JsonSerializable
         return $this->type->toScript();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/generator/templates/static/ReferencedType.php
+++ b/generator/templates/static/ReferencedType.php
@@ -26,8 +26,7 @@ class ReferencedType implements Type, JsonSerializable
         return $this->type->toScript();
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/generator/templates/static/ReferencedType.php
+++ b/generator/templates/static/ReferencedType.php
@@ -26,7 +26,8 @@ class ReferencedType implements Type, JsonSerializable
         return $this->type->toScript();
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/generator/templates/twig/Graph.php.twig
+++ b/generator/templates/twig/Graph.php.twig
@@ -280,8 +280,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }
@@ -307,8 +306,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return $this->has($type, $identifier);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 

--- a/generator/templates/twig/Graph.php.twig
+++ b/generator/templates/twig/Graph.php.twig
@@ -280,7 +280,8 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }
@@ -299,21 +300,22 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return explode('.', $key);
     }
 
-    public function offsetExists(mixed $offset): bool
+    public function offsetExists($offset): bool
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->has($type, $identifier);
     }
 
-    public function offsetGet(mixed $offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->get($type, $identifier);
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetSet($offset, $value): void
     {
         $identifier = $offset;
 
@@ -324,7 +326,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         $this->set($value, $identifier);
     }
 
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset($offset): void
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 

--- a/generator/templates/twig/Graph.php.twig
+++ b/generator/templates/twig/Graph.php.twig
@@ -280,7 +280,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/generator/templates/twig/Graph.php.twig
+++ b/generator/templates/twig/Graph.php.twig
@@ -299,21 +299,21 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return explode('.', $key);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->has($type, $identifier);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->get($type, $identifier);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $identifier = $offset;
 
@@ -324,7 +324,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         $this->set($value, $identifier);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 

--- a/generator/templates/twig/MultiTypedEntity.php.twig
+++ b/generator/templates/twig/MultiTypedEntity.php.twig
@@ -167,7 +167,8 @@ class MultiTypedEntity implements Type, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/generator/templates/twig/MultiTypedEntity.php.twig
+++ b/generator/templates/twig/MultiTypedEntity.php.twig
@@ -167,7 +167,7 @@ class MultiTypedEntity implements Type, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/generator/templates/twig/MultiTypedEntity.php.twig
+++ b/generator/templates/twig/MultiTypedEntity.php.twig
@@ -167,8 +167,7 @@ class MultiTypedEntity implements Type, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -69,22 +69,22 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return new ReferencedType($this);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return array_key_exists($offset, $this->properties);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->getProperty($offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->setProperty($offset, $value);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->properties[$offset]);
     }

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -142,7 +142,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -74,8 +74,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return array_key_exists($offset, $this->properties);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getProperty($offset);
     }
@@ -143,8 +142,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -69,22 +69,23 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return new ReferencedType($this);
     }
 
-    public function offsetExists(mixed $offset): bool
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->properties);
     }
 
-    public function offsetGet(mixed $offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         return $this->getProperty($offset);
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetSet($offset, $value): void
     {
         $this->setProperty($offset, $value);
     }
 
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset($offset): void
     {
         unset($this->properties[$offset]);
     }
@@ -142,7 +143,8 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -1155,8 +1155,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }
@@ -1182,8 +1181,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return $this->has($type, $identifier);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -1155,7 +1155,8 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }
@@ -1174,21 +1175,22 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return explode('.', $key);
     }
 
-    public function offsetExists(mixed $offset): bool
+    public function offsetExists($offset): bool
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->has($type, $identifier);
     }
 
-    public function offsetGet(mixed $offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->get($type, $identifier);
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetSet($offset, $value): void
     {
         $identifier = $offset;
 
@@ -1199,7 +1201,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         $this->set($value, $identifier);
     }
 
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset($offset): void
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -1174,21 +1174,21 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return explode('.', $key);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->has($type, $identifier);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 
         return $this->get($type, $identifier);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $identifier = $offset;
 
@@ -1199,7 +1199,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         $this->set($value, $identifier);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         [$type, $identifier] = $this->getTypeAndIdentifier($offset);
 

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -1155,7 +1155,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/MultiTypedEntity.php
+++ b/src/MultiTypedEntity.php
@@ -1042,8 +1042,7 @@ class MultiTypedEntity implements Type, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/MultiTypedEntity.php
+++ b/src/MultiTypedEntity.php
@@ -1042,7 +1042,7 @@ class MultiTypedEntity implements Type, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/MultiTypedEntity.php
+++ b/src/MultiTypedEntity.php
@@ -1042,7 +1042,8 @@ class MultiTypedEntity implements Type, JsonSerializable
         return '<script type="application/ld+json">'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/ReferencedType.php
+++ b/src/ReferencedType.php
@@ -26,7 +26,7 @@ class ReferencedType implements Type, JsonSerializable
         return $this->type->toScript();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/ReferencedType.php
+++ b/src/ReferencedType.php
@@ -26,8 +26,7 @@ class ReferencedType implements Type, JsonSerializable
         return $this->type->toScript();
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/ReferencedType.php
+++ b/src/ReferencedType.php
@@ -26,7 +26,8 @@ class ReferencedType implements Type, JsonSerializable
         return $this->type->toScript();
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }


### PR DESCRIPTION
PHP 8.1 added type hints to `ArrayAccess` and `JsonSerializable` functions. This PR adds those hints to avoid incompatible signature errors.