### PR TITLE
Unescape slashes in output

### DIFF
--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -160,7 +160,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -1191,7 +1191,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/src/MultiTypedEntity.php
+++ b/src/MultiTypedEntity.php
@@ -1078,7 +1078,7 @@ class MultiTypedEntity implements Type, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -156,7 +156,7 @@ it('can create an ld json script tag', function () {
     $type->setProperty('foo', 'bar');
 
     $expected = '<script type="application/ld+json">'.
-        '{"@context":"https:\/\/schema.org","@type":"DummyType","foo":"bar"}'.
+        '{"@context":"https://schema.org","@type":"DummyType","foo":"bar"}'.
         '</script>';
 
     expect($type->toScript())->toBe($expected);
@@ -170,7 +170,7 @@ it('can create an ld json script tag with nonce attribute', function () {
     $type->setNonce('baz');
 
     $expected = '<script type="application/ld+json" nonce="baz">'.
-        '{"@context":"https:\/\/schema.org","@type":"DummyType","foo":"bar"}'.
+        '{"@context":"https://schema.org","@type":"DummyType","foo":"bar"}'.
         '</script>';
 
     expect($type->toScript())->toBe($expected);
@@ -273,7 +273,7 @@ it('can be casted to string', function () {
     $type->setProperty('foo', 'bar');
 
     $expected = '<script type="application/ld+json">'.
-        '{"@context":"https:\/\/schema.org","@type":"DummyType","foo":"bar"}'.
+        '{"@context":"https://schema.org","@type":"DummyType","foo":"bar"}'.
         '</script>';
 
     expect((string) $type)->toBe($expected);

--- a/tests/GeneratedTypeSmokeTest.php
+++ b/tests/GeneratedTypeSmokeTest.php
@@ -20,7 +20,7 @@ it('can be rendered with properties', function () {
         ->email('info@spatie.be');
 
     $expected = '<script type="application/ld+json">'.
-        '{"@context":"https:\/\/schema.org","@type":"LocalBusiness","name":"Spatie","email":"info@spatie.be"}'.
+        '{"@context":"https://schema.org","@type":"LocalBusiness","name":"Spatie","email":"info@spatie.be"}'.
         '</script>';
 
     expect($localBusiness->toScript())->toBe($expected);
@@ -32,7 +32,7 @@ it('can be rendered with child properties', function () {
         ->contactPoint(Schema::contactPoint()->areaServed('Worldwide'));
 
     $expected = '<script type="application/ld+json">'.
-        '{"@context":"https:\/\/schema.org","@type":"LocalBusiness","name":"Spatie",'.
+        '{"@context":"https://schema.org","@type":"LocalBusiness","name":"Spatie",'.
         '"contactPoint":{"@type":"ContactPoint","areaServed":"Worldwide"}}'.
         '</script>';
 

--- a/tests/GraphIdentifierTest.php
+++ b/tests/GraphIdentifierTest.php
@@ -13,7 +13,7 @@ it('can manipulate item', function () {
     $graph->get(Organization::class, Graph::IDENTIFIER_DEFAULT)->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
     );
 });
 
@@ -23,7 +23,7 @@ it('can get existing or new item', function () {
     $graph->getOrCreate(Organization::class, Graph::IDENTIFIER_DEFAULT)->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
     );
 });
 
@@ -33,7 +33,7 @@ it('can link items', function () {
     $graph->getOrCreate(Organization::class, Graph::IDENTIFIER_DEFAULT)->name('My Company')->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"},{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"},{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
     );
 });
 
@@ -44,7 +44,7 @@ it('can hide single items', function () {
     $graph->hide(Organization::class, 'astrotomic');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"spatie"}]}</script>'
     );
 });
 
@@ -56,7 +56,7 @@ it('can hide all items', function () {
     $graph->product()->brand($graph->organization('spatie'));
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
     );
 });
 
@@ -69,7 +69,7 @@ it('can show all items', function () {
     $graph->show(Organization::class, null);
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Organization","name":"astrotomic"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Organization","name":"astrotomic"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
     );
 });
 
@@ -82,7 +82,7 @@ it('can show single item if everything is hidden', function () {
     $graph->show(Organization::class, 'spatie');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
     );
 });
 
@@ -95,7 +95,7 @@ it('can hide single item if everything is shown', function () {
     $graph->hide(Organization::class, 'astrotomic');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
     );
 });
 
@@ -107,7 +107,7 @@ it('can show single item if everything is shown', function () {
     $graph->show(Organization::class, 'spatie');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
     );
 });
 
@@ -118,7 +118,7 @@ it('can show single item', function () {
     $graph->product()->brand($graph->organization('spatie'));
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
     );
 });
 
@@ -130,7 +130,7 @@ it('can show single item before it was created', function () {
     $graph->product()->brand($graph->organization('spatie'));
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"spatie"},{"@type":"Product","brand":{"@type":"Organization","name":"spatie"}}]}</script>'
     );
 });
 

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -14,7 +14,7 @@ use Spatie\SchemaOrg\Type;
 it('can render empty', function () {
     $graph = new Graph();
 
-    expect((string) $graph)->toBe('<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[]}</script>');
+    expect((string) $graph)->toBe('<script type="application/ld+json">{"@context":"https://schema.org","@graph":[]}</script>');
 });
 
 it('can render single item', function () {
@@ -22,7 +22,7 @@ it('can render single item', function () {
     $graph->add(Schema::organization()->name('My Company'));
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company"}]}</script>'
     );
 });
 
@@ -32,7 +32,7 @@ it('can render multiple items', function () {
     $graph->add(Schema::product()->name('My Product'));
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company"},{"@type":"Product","name":"My Product"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company"},{"@type":"Product","name":"My Product"}]}</script>'
     );
 });
 
@@ -42,7 +42,7 @@ it('can manipulate item', function () {
     $graph->get(Organization::class)->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
     );
 });
 
@@ -52,7 +52,7 @@ it('can get existing or new item', function () {
     $graph->getOrCreate(Organization::class)->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"}]}</script>'
     );
 });
 
@@ -62,7 +62,7 @@ it('can link items', function () {
     $graph->getOrCreate(Organization::class)->name('My Company')->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"},{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"},{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
     );
 });
 
@@ -73,7 +73,7 @@ it('can hide items', function () {
     $graph->getOrCreate(Organization::class)->name('My Company')->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
     );
 });
 
@@ -86,7 +86,7 @@ it('can show again hidden items', function () {
     $graph->show(Organization::class);
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"},{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","email":"contact@example.com"},{"@type":"Product","brand":{"@type":"Organization","name":"My Company","email":"contact@example.com"}}]}</script>'
     );
 });
 
@@ -130,7 +130,7 @@ it('can call overloaded schema methods', function () {
 
     expect($organization)->toBeInstanceOf(Organization::class);
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company"}]}</script>'
     );
 });
 
@@ -143,7 +143,7 @@ it('can call overloaded schema methods with callback', function () {
     expect($graph)->toBeInstanceOf(Graph::class);
     expect($graph->organization())->toBeInstanceOf(Organization::class);
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company"}]}</script>'
     );
 });
 
@@ -159,7 +159,7 @@ it('can call overloaded schema methods with callback multiple times', function (
     expect($graph)->toBeInstanceOf(Graph::class);
     expect($graph->organization())->toBeInstanceOf(Organization::class);
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Organization","name":"My Company","description":"This is my awesome Company."}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"My Company","description":"This is my awesome Company."}]}</script>'
     );
 });
 
@@ -179,7 +179,7 @@ it('can call overloaded schema methods with callback and access schemas in child
     expect($graph->organization())->toBeInstanceOf(Organization::class);
     expect($graph->product())->toBeInstanceOf(Product::class);
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","name":"My Product","brand":{"@type":"Organization","name":"My Company"}}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Product","name":"My Product","brand":{"@type":"Organization","name":"My Company"}}]}</script>'
     );
 });
 
@@ -217,7 +217,7 @@ it('can use references', function () {
         ->email('contact@example.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@graph":[{"@type":"BlogPosting","author":{"@id":"https:\/\/example.com\/#organization"},"publisher":{"@id":"https:\/\/example.com\/#organization"},"@id":"https:\/\/example.com\/blog\/my-post\/#blogPosting"},{"@type":"Organization","name":"organization","url":"https:\/\/example.com","email":"contact@example.com","@id":"https:\/\/example.com\/#organization"}]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"BlogPosting","author":{"@id":"https://example.com/#organization"},"publisher":{"@id":"https://example.com/#organization"},"@id":"https://example.com/blog/my-post/#blogPosting"},{"@type":"Organization","name":"organization","url":"https://example.com","email":"contact@example.com","@id":"https://example.com/#organization"}]}</script>'
     );
 });
 
@@ -227,7 +227,7 @@ it('can be initialized with different context', function () {
     expect($graph->getContext())->toBe('https://foobar.com');
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/foobar.com","@graph":[]}</script>'
+        '<script type="application/ld+json">{"@context":"https://foobar.com","@graph":[]}</script>'
     );
 });
 
@@ -243,6 +243,6 @@ it('can be initialized with complex context', function () {
     ]);
 
     expect($graph->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":{"@vocab":"https:\/\/schema.org\/","@base":"https:\/\/domain.com\/"},"@graph":[]}</script>'
+        '<script type="application/ld+json">{"@context":{"@vocab":"https://schema.org/","@base":"https://domain.com/"},"@graph":[]}</script>'
     );
 });

--- a/tests/MultiTypedEntityTest.php
+++ b/tests/MultiTypedEntityTest.php
@@ -10,7 +10,7 @@ it('can render empty', function () {
     $mte = new MultiTypedEntity();
 
     expect((string) $mte)->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":[]}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@type":[]}</script>'
     );
 });
 
@@ -19,7 +19,7 @@ it('can render single item', function () {
     $mte->hotelRoom()->name('The Presidential Suite');
 
     expect($mte->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":["HotelRoom"],"name":"The Presidential Suite"}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@type":["HotelRoom"],"name":"The Presidential Suite"}</script>'
     );
 });
 
@@ -41,6 +41,6 @@ it('can render multiple items', function () {
     });
 
     expect($mte->toScript())->toBe(
-        '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":["HotelRoom","Product"],"name":"The Presidential Suite","offers":{"@type":"Offer","name":"One Night","price":100000,"priceCurrency":"USD"},"aggregateRating":{"@type":"AggregateRating","bestRating":5,"worstRating":4}}</script>'
+        '<script type="application/ld+json">{"@context":"https://schema.org","@type":["HotelRoom","Product"],"name":"The Presidential Suite","offers":{"@type":"Offer","name":"One Night","price":100000,"priceCurrency":"USD"},"aggregateRating":{"@type":"AggregateRating","bestRating":5,"worstRating":4}}</script>'
     );
 });


### PR DESCRIPTION
JSON LD works without escaping slashes, The examples on schema.org don't use slashes. This makes it easier to read and easier to copy paste urls to test them.