### PR TITLE
Resolve @id without cascading toArray() in ReferencedType

### DIFF
--- a/src/ReferencedType.php
+++ b/src/ReferencedType.php
@@ -17,8 +17,23 @@ class ReferencedType implements Type, JsonSerializable
     public function toArray(): array
     {
         return [
-            '@id' => $this->type->toArray()['@id'] ?? null,
+            '@id' => $this->resolveIdentifier(),
         ];
+    }
+
+    protected function resolveIdentifier()
+    {
+        if (! $this->type instanceof BaseType) {
+            return $this->type->toArray()['@id'] ?? null;
+        }
+
+        $identifier = $this->type->getProperty('identifier');
+
+        if ($identifier === null || $identifier instanceof Type) {
+            $identifier = $this->type->getProperty('@id');
+        }
+
+        return $identifier instanceof Type ? null : $identifier;
     }
 
     public function toScript(): string

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -332,6 +332,23 @@ it('can reference type by identifier', function () {
     expect($type2->toArray())->toBe($expected);
 });
 
+it('can reference two types that reference each other without looping', function () {
+    $type1 = new DummyType();
+    $type1->setProperty('identifier', '#1');
+    $type2 = new AnotherDummyType();
+    $type2->setProperty('identifier', '#2');
+
+    $type1->setProperty('partner', $type2->referenced());
+    $type2->setProperty('partner', $type1->referenced());
+
+    expect($type1->toArray())->toBe([
+        '@context' => 'https://schema.org',
+        '@type' => 'DummyType',
+        'partner' => ['@id' => '#2'],
+        '@id' => '#1',
+    ]);
+});
+
 class DummyType extends BaseType
 {
 }


### PR DESCRIPTION
## Summary

Fixes #234. `ReferencedType::toArray()` extracted the wrapped type's `@id` by calling `toArray()` on it, which fully serializes every property. When two nodes reference each other (the example from the issue: `organization.employees` contains `person.referenced()` while `person.worksFor` is `organization.referenced()`), that triggers unbounded recursion and a memory exhaustion fatal error.

## Changes

- `ReferencedType::toArray()` now reads the identifier directly from the wrapped type's properties (via `getProperty('identifier')` / `getProperty('@id')`) instead of serializing the whole subtree.
- Falls back to the previous `toArray()` path when the wrapped `Type` is not a `BaseType` (`MultiTypedEntity`, user-defined `Type` implementations), so existing behaviour is preserved for those.
- Added a regression test in `tests/BaseTypeTest.php` where two types reference each other. Without the fix the test hits the memory limit, with the fix it asserts the expected single `@id` payload.