### PR TITLE
Escape HTML tags in toScript() output to prevent script break-out

### DIFF
--- a/generator/templates/static/BaseType.php
+++ b/generator/templates/static/BaseType.php
@@ -160,7 +160,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/generator/templates/twig/Graph.php.twig
+++ b/generator/templates/twig/Graph.php.twig
@@ -298,7 +298,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/generator/templates/twig/MultiTypedEntity.php.twig
+++ b/generator/templates/twig/MultiTypedEntity.php.twig
@@ -185,7 +185,7 @@ class MultiTypedEntity implements Type, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/src/BaseType.php
+++ b/src/BaseType.php
@@ -160,7 +160,7 @@ abstract class BaseType implements Type, ArrayAccess, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -1208,7 +1208,7 @@ class Graph implements Type, ArrayAccess, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/src/MultiTypedEntity.php
+++ b/src/MultiTypedEntity.php
@@ -1095,7 +1095,7 @@ class MultiTypedEntity implements Type, JsonSerializable
 
     public function toScript(): string
     {
-        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).'</script>';
+        return '<script type="application/ld+json"'.$this->nonceAttr().'>'.json_encode($this, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG).'</script>';
     }
 
     public function jsonSerialize(): mixed

--- a/tests/BaseTypeTest.php
+++ b/tests/BaseTypeTest.php
@@ -162,6 +162,18 @@ it('can create an ld json script tag', function () {
     expect($type->toScript())->toBe($expected);
 });
 
+it('escapes html tags in property values to prevent script break-out', function () {
+    $type = new DummyType();
+
+    $type->setProperty('foo', '</script><script>alert(1)</script>');
+
+    $expected = '<script type="application/ld+json">'.
+        '{"@context":"https://schema.org","@type":"DummyType","foo":"\u003C/script\u003E\u003Cscript\u003Ealert(1)\u003C/script\u003E"}'.
+        '</script>';
+
+    expect($type->toScript())->toBe($expected);
+});
+
 it('can create an ld json script tag with nonce attribute', function () {
     $type = new DummyType();
 


### PR DESCRIPTION
## Summary

Reported privately: since 3.23.1 (PR #223), `toScript()` output could be broken out of by a property value containing `</script>`. The `JSON_UNESCAPED_SLASHES` flag added in that PR removed the backslash-escape of `/` that previously neutralized this vector.

```php
Schema::localBusiness()->name('</script><script>alert(1)</script>')->toScript();
```

produced a literal `</script><script>alert(1)</script>` inside the `<script>` block, allowing arbitrary HTML/JS injection when the property value is attacker-controlled.

This PR adds `JSON_HEX_TAG` to the `json_encode` flags in `BaseType::toScript()`, `Graph::toScript()`, and `MultiTypedEntity::toScript()` (and the matching generator templates). `<` and `>` are now serialized as `\u003C` / `\u003E`, which is valid JSON-LD (and recommended by Google's structured-data guidelines) but cannot be parsed as an HTML tag by the browser.

## Changes

- `src/BaseType.php`, `src/Graph.php`, `src/MultiTypedEntity.php`: add `JSON_HEX_TAG`
- `generator/templates/...`: mirror the change so regeneration stays in sync
- `tests/BaseTypeTest.php`: regression test asserting `</script>` break-out is neutralized

Affected releases: 3.23.1 through 4.0.1.