### PR TITLE
Upgrade test suite to Pest 5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.5', '8.4', '8.3', '8.2']
+                php: ['8.5', '8.4']
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,4 +29,4 @@ jobs:
               run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             - name: Execute tests
-              run: vendor/bin/pest --coverage-text --coverage-clover=coverage.clover
+              run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "homepage": "https://github.com/spatie/schema-org",
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "graham-campbell/analyzer": "^5.0.0",
         "illuminate/collections": "^10",
         "league/flysystem": "^3.30",
-        "pestphp/pest": "^2.36.1 || ^3.0",
+        "pestphp/pest": "^5.0.4",
         "symfony/console": "^6.0 || ^7.3.4",
         "twig/twig": "^3.21.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticProperties="false"


### PR DESCRIPTION
Pest 5 requires PHP 8.4, so the package now requires `php: ^8.4` and the test matrix drops 8.2 and 8.3.

Pest 5 exits non-zero when `--coverage-text` is passed without a coverage driver, so the (never uploaded) coverage flags are dropped from CI. `phpunit.xml.dist` now points at the PHPUnit 13.2 schema. No test code changes were needed.